### PR TITLE
Fix duplicated items in bs-popover with ng-repeat

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -59,7 +59,9 @@ angular.module('$strap.directives')
 							var popover = element.data('popover'),
 								$tip = popover.tip();
 
-							$compile($tip)(scope);
+							if (!$tip.hasClass("ng-scope")) {
+								$compile($tip)(scope);
+							}
 
 							setTimeout(function() { // refresh position on nextTick
 								popover.refresh();


### PR DESCRIPTION
For some reason, bootstrap is calling the content() function twice. This
doesn't necessarily produce any ill effects, but if your bs-popover
partial contained an ng-repeat, the ng-repeat would be replicated once
for every element in the collection.

For example, this:

```
 $scope.things = [{name: "A"}, {name: "B"}, {name: "C"}];

 <ul>
   <li ng-repeat="thing in things">{{thing.name}}</li>
  </ul>
```

Would yield a popover that appeared like this:

```
- A
- A
- A
- B
- B
- B
- C
- C
- C
```

But it should have appeared like this:

```
- A
- B
- C
```
