### PR TITLE
Real fix for the duplicate items in ng-repeat within bs-popover

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -74,6 +74,9 @@ angular.module('$strap.directives')
 
 				// Bootstrap override to provide events & tip() reference & refresh positions
 				var popover = element.data('popover');
+				popover.hasContent = function() {
+					return popover.getTitle() || template;
+				}
 				popover.refresh = function() {
 					var $tip = this.tip(), inside, pos, actualWidth, actualHeight, placement, tp;
 


### PR DESCRIPTION
If your popover lacks a hasContent() function, Bootstrap will end up calling
the content() function twice, and in the case of bs-popover, this would result
in a redundant $compile.

This doesn't necessarily produce any ill effects, but if your bs-popover
partial contained an ng-repeat, the ng-repeat would be replicated once
for every element in the collection.

For example, this:

  Controller:
  `$scope.things = [{name: "A"}, {name: "B"}, {name: "C"}];`

  Partial:

```
<div>
 This is my popover!
  <ul>
     <li ng-repeat="thing in things">{{thing.name}}</li>
  </ul>
</div>
```

_Output:_

 This is my popover!
- A
- A
- A
- B
- B
- B
- C
- C
- C

_Expected Output:_

This is my popover!
- A
- B
- C
