### PR TITLE
add new typeahead value as first one for other inputs

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -35,6 +35,16 @@ angular.module('$strap.directives')
 				}
 			});
 
+			// add entered element into typeahead array for other fields
+			element.bind('blur', function() {
+				var new_value = element.val();
+				if ( new_value.length > 1 && $.inArray( new_value, value ) === -1 ) { // IE doesn't have .indexOf
+					scope.$apply( function() {
+						value.unshift( element.val() );
+					});
+				}
+			});
+
 		}
 	};
 


### PR DESCRIPTION
I have use-case in which i have multiple organisation typeaheads on
same page, so I want users to be able to typeahead name of organisation
which they entered in one of previous inputs on page (otherwise,
typeahead suggest only organisations available at page load time).
