### PR TITLE
Update src/directives/typeahead.js

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -1,4 +1,3 @@
-
 angular.module('$strap.directives')
 
 .directive('bsTypeahead', ['$parse', function($parse) {
@@ -21,8 +20,21 @@ angular.module('$strap.directives')
 			});
 
 			element.attr('data-provide', 'typeahead');
+			
+			var dataSource = $parse(attr.bsTypeaheadQuery);
+                        
+                        // the bs-typeahead-query contains the name of a function declared in the current scope
+                        // that will be used as the data-source
+                        if (dataSource.name != "noop") {
+                            dataSource = dataSource(scope);
+                        }
+                        else {
+                       	    // if the attribute isn't defined use the value scope attribute
+                            dataSource = function(query) { return value; };
+                        }
+                        
 			element.typeahead({
-				source: function(query) { return value; },
+				source: dataSource,
 				items: attr.items,
 				updater: function(value) {
 					// If we have a controller (i.e. ngModelController) then wire it up


### PR DESCRIPTION
Added the bs-typeahead-query attribute to specify a query function as
data source instead of a fixed array.
