### PR TITLE
Add data-hide attribute to the bs-popover directive

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -38,14 +38,16 @@ angular.module('$strap.directives')
 				// Handle `data-unique` attribute
 				if(!!attr.unique) {
 					element.on('show', function(ev) {
-						// Hide any active popover except self
-						$(".popover.in").each(function() {
-							var $this = $(this),
-								popover = $this.data('popover');
-							if(popover && !popover.$element.is(element)) {
-								$this.popover('hide');
-							}
-						});
+						_hideAllPopversExcept(element);
+					});
+				}
+
+				// Handle `data-hide` attribute
+				if(attr.hide) {
+					scope.$watch(attr.hide, function(val) {
+						if (val) {
+							_hidePopover(element);
+						}
 					});
 				}
 
@@ -140,6 +142,31 @@ angular.module('$strap.directives')
 
 			});
 
+			function _eachPopover(callback) {
+				$(".popover.in").each(function() {
+					var $this = $(this),
+						popover = $this.data('popover');
+					if (popover) {
+						callback($this, popover);
+					}
+				});
+			}
+
+			function _hideAllPopversExcept(element) {
+				_eachPopover(function($elem, popover) {
+					if (!popover.$element.is(element)) {
+						$elem.popover('hide');
+					}
+				});
+			}
+
+			function _hidePopover(element) {
+				_eachPopover(function($elem, popover ){
+					if (popover.$element.is(element)) {
+						$elem.popover('hide');
+					}
+				});
+			}
 		}
 	};
 


### PR DESCRIPTION
This allows callers to specify a scope variable that, when truthy,
causes the popover to be hidden. Very useful when you need to dismiss
a popover from its parent scope.

Usage example:

```
    <button bs-popover="'/my/partial.html'" data-hide="foo">Click Me</button>
```

(when $scope.foo becomes truthy, this popover will be hidden)
