### PR TITLE
Update src/directives/typeahead.js

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -1,4 +1,3 @@
-
 angular.module('$strap.directives')
 
 .directive('bsTypeahead', ['$parse', function($parse) {
@@ -22,7 +21,7 @@ angular.module('$strap.directives')
 
 			element.attr('data-provide', 'typeahead');
 			element.typeahead({
-				source: function(query) { return value; },
+				source: value,
 				minLength: attrs.minLength || 1,
 				items: attrs.items,
 				updater: function(value) {


### PR DESCRIPTION
I propose this modification to let typeahead manage functions as data 
source, so the data set could be dynamically generated for example executing a query to a restful service (see on http://twitter.github.com/bootstrap/javascript.html#typeahead 
function as source parameter).
Without the modification if you assign a function as a value for the bs-typeahead attribute
the drop-down list doesn't show any value (an example at http://plnkr.co/edit/WbjtvcShroFHyxOpAeVb)
A working example with the modification can be found at http://plnkr.co/edit/QY94ji9kGSeyQos5KfWC
