### PR TITLE
Let typeahead dropdown-menu show up again after it re-obtains focus

### DIFF
--- a/dist/angular-strap.js
+++ b/dist/angular-strap.js
@@ -840,9 +840,9 @@ angular.module('$strap.directives')
 
             typeahead.focus = function (e) {
                 this.lookup();
-            }
+            };
 
-            element.on('focus', $.proxy(typeahead.focus, typeahead))
+            element.on('focus', $.proxy(typeahead.focus, typeahead));
 
 			// Fixes #2043: allows minLength of zero to enable show all for typeahead
 			typeahead.lookup = function (event) {

--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -40,9 +40,9 @@ angular.module('$strap.directives')
 
             typeahead.focus = function (e) {
                 this.lookup();
-            }
+            };
 
-            element.on('focus', $.proxy(typeahead.focus, typeahead))
+            element.on('focus', $.proxy(typeahead.focus, typeahead));
 
 			// Fixes #2043: allows minLength of zero to enable show all for typeahead
 			typeahead.lookup = function (event) {


### PR DESCRIPTION
Currently the dropdown-menu of typeahead will disappear when typeahead blurs and re-obtains focus. Let it show up again may improve user experience.
