### PR TITLE
Fix path in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git://github.com/angular-strap/angular-strap.git"
   },
-  "main": "./build/angular-strap.min.js",
+  "main": "./dist/angular-strap.min.js",
   "dependencies": {
     "jquery": "~1.9.1",
     "bootstrap": "~2.3.0"


### PR DESCRIPTION
Component.json error prevents automated copy of assets in grunt task

When using `grunt-bower-task` to automatically install Bower assets to a lib directory, the path to the distribution files are incorrect.

Unfortunately, to fix this across the board, you're going to need to update / re-tag everything that has been versioned up to this point.

i.e. fix component.json, re-tag 0.6.4 .. fix component.json, re-tag 0.6.3, etc, etc
