### PR TITLE
Make sure :'s are converted to -'s, allowing CORS.

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -20,7 +20,7 @@ angular.module('$strap.directives')
 				}
 
 				// Build modal object
-				var id = getter(scope).replace('.html', '').replace(/\//g, '-').replace(/\./g, '-') + '-' + scope.$id;
+				var id = getter(scope).replace('.html', '').replace(/[\/|\.|:]/g, "-") + '-' + scope.$id;
 				var $modal = $('<div class="modal hide" tabindex="-1"></div>')
 					.attr('id', id)
 					.attr('data-backdrop', attr.backdrop || true)


### PR DESCRIPTION
Couldn't get the test suite running, so please test.

We're calling modal templates from another domain, hence the problem.
