### PR TITLE
Alert stack cannot remove elements from deep object array references.

### DIFF
--- a/src/directives/alert.js
+++ b/src/directives/alert.js
@@ -71,13 +71,23 @@ angular.module('$strap.directives')
 					ev.preventDefault();
 
 					element.removeClass('in');
-						console.warn(scope.$parent);
 
 					removeElement = function() {
 						element.trigger('closed');
 						if(scope.$parent) {
 							scope.$parent.$apply(function() {
-								scope.$parent[parentArray].splice(scope.$index, 1);
+								var path = parentArray.split('.');
+								var curr = scope.$parent;
+
+								for (var i = 0; i < path.length; ++i) {
+									if (curr) {
+										curr = curr[path[i]];
+									}
+								}
+
+								if (curr) {
+									curr.splice(scope.$index, 1);
+								}
 							});
 						}
 					};

--- a/test/unit/directives/alertSpec.js
+++ b/test/unit/directives/alertSpec.js
@@ -20,8 +20,16 @@ describe('alert', function () {
 
   var templates = {
     'default': {
-      scope: {alert: {type:'error', title: 'Holy guacamole!', content: 'Hello Alert, <pre>2 + 3 = {{ 2 + 3 }}</pre>'}},
+      scope: {alert:{type:'error', title: 'Holy guacamole!', content: 'Hello Alert, <pre>2 + 3 = {{ 2 + 3 }}</pre>'}},
       element: '<div class="alert fade in" bs-alert="alert"></div>'
+    },
+    'alertStack': {
+      scope: {alerts:[{type:'error', title: 'Holy guacamole!', content: 'Hello Alert, <pre>2 + 3 = {{ 2 + 3 }}</pre>'}]},
+      element: '<div class="alerts"><div class="alert" ng-repeat="alert in alerts" bs-alert="alert"></div></div>'
+    },
+    'deepAlertStack': {
+      scope: {deep:{alerts:[{type:'error', title: 'Holy guacamole!', content: 'Hello Alert, <pre>2 + 3 = {{ 2 + 3 }}</pre>'}]}},
+      element: '<div class="alert"><div class="alert" ng-repeat="alert in deep.alerts" bs-alert="alert"></div></div>'
     }
   };
 
@@ -60,4 +68,15 @@ describe('alert', function () {
     expect(elm.hasClass('info')).toBe(false);
   });
 
+  it('should correctly remove alert from stack', function() {
+    var elm = compileDirective('alertStack').parent();
+    $('button', elm).click();
+    expect(scope.alerts.length).toBe(0);
+  });
+
+  it('should correctly remove alert from deep stack', function() {
+    var elm = compileDirective('deepAlertStack');
+    $("button", elm).click();
+    expect(scope.deep.alerts.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Basically I have something like this:

``` html
<div class="alert fade" ng-repeat="alert in obj.alerts" bs-alert="alert"></div>
```

But the code that currently will look for an element called 'obj.alerts' in the scope, rather than 'obj', and then the attribute named 'alerts' on the 'obj'.

This comes with two tests, one of which was passing prior to the fix.

Would you mind doing a release after pulling this in? (I like to use webjars, and it's easier to maintain with real releases.)
