### PR TITLE
fix: do not show typeahead minLength=0 if the input is not empty

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -53,7 +53,9 @@ angular.module('$strap.directives')
 				setTimeout(function() { // Push to the event loop to make sure element.typeahead is defined (breaks tests otherwise)
 					element.on('focus', function() {
 						// run typeahead.lookup only of element value is empty
-						element.val().length == 0 && setTimeout(element.typeahead.bind(element, 'lookup'), 200);
+						if (element.val().length === 0) {
+							setTimeout(element.typeahead.bind(element, 'lookup'), 200);
+						}
 					});
 				});
 			}


### PR DESCRIPTION
This is very straining behavior, please merge.
