### PR TITLE
Emit the Bootstrap modal events (show, shown, hide, hidden).

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -50,6 +50,22 @@ angular.module('$strap.directives')
         };
         scope.dismiss = scope.hide;
 
+        $modal.on("show", function(event) {
+          scope.$emit("modal-show", event);
+        });
+
+        $modal.on("shown", function(event) {
+          scope.$emit("modal-shown", event);
+        });
+
+        $modal.on("hide", function(event) {
+          scope.$emit("modal-hide", event);
+        });
+
+        $modal.on("hidden", function(event) {
+          scope.$emit("modal-hidden", event);
+        });
+
       });
     }
   };

--- a/test/unit/directives/modalSpec.js
+++ b/test/unit/directives/modalSpec.js
@@ -96,4 +96,46 @@ describe('modal', function () {
     }, 100);*/
   });
 
+  describe("events", function() {
+
+    beforeEach(function() {
+      this.elm = compileDirective();
+      this.$modal = $(this.elm.attr('href'));
+      this.event = null;
+    });
+
+    it('should emit an event on show', function () {
+      scope.$on("modal-show", function (e) {
+        event = e;
+      });
+      this.$modal.modal({show: true});
+      expect(event).not.toBeNull();
+    });
+
+    it('should emit an event on shown', function () {
+      scope.$on("modal-shown", function (e) {
+        event = e;
+      });
+      this.$modal.modal({show: true});
+      expect(event).not.toBeNull();
+    });
+
+    it('should emit an event on hide', function () {
+      scope.$on("modal-hide", function (e) {
+        event = e;
+      });
+      this.$modal.modal({hide: true});
+      expect(event).not.toBeNull();
+    });
+
+    it('should emit an event on hidden', function () {
+      scope.$on("modal-hidden", function (e) {
+        event = e;
+      });
+      this.$modal.modal({hide: true});
+      expect(event).not.toBeNull();
+    });
+
+  });
+
 });


### PR DESCRIPTION
This pull request adds the emitting of the Bootstrap modal events; show, shown, hide, hidden. The use case for this is when you want to load remote resources when the modal is shown, but only when it's shown.
