### PR TITLE
Datepicker validation should use the language default format

### DIFF
--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -36,7 +36,7 @@ angular.module('$strap.directives')
         return new RegExp('^' + re + '$', ['i']);
       };
 
-      var dateFormatRegexp = isTouch ? 'yyyy/mm/dd' : regexpForDateFormat(attrs.dateFormat || 'mm/dd/yyyy'/*, {mask: !!attrs.uiMask}*/);
+      var dateFormatRegexp = isTouch ? 'yyyy/mm/dd' : regexpForDateFormat(attrs.dateFormat || ($.fn.datepicker.dates[attrs.language] && $.fn.datepicker.dates[attrs.language].format) || 'mm/dd/yyyy'/*, {mask: !!attrs.uiMask}*/);
 
       // Handle date validity according to dateFormat
       if(controller) {


### PR DESCRIPTION
If the datepicker has something like `language="it"` the input may not be validated by AngularJS because the default date format is the American one ("mm/dd/yyyy").
I think datepicker should still give priority to `attrs.dateFormat` but, if it is not set, it should rely on the language default format first, before falling back to the US one.
