### PR TITLE
Modal : In e2e Firefox navigate to href of the element with directive bsModal

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -90,7 +90,7 @@ angular.module('$strap.directives')
       };
 
       $q.when($modal(options)).then(function onSuccess(modal) {
-        iElement.attr('href', '#' + modal.attr('id')).attr('data-toggle', 'modal');
+        iElement.attr('data-target', '#' + modal.attr('id')).attr('data-toggle', 'modal');
       });
 
     }

--- a/test/unit/directives/modalSpec.js
+++ b/test/unit/directives/modalSpec.js
@@ -45,15 +45,15 @@ describe('modal', function () {
   it('should fetch the partial and build the modal', function () {
     var elm = compileDirective();
     expect(elm.attr('data-toggle')).toBe('modal');
-    expect(elm.attr('href')).toBeDefined();
-    var $modal = $(elm.attr('href'));
+    expect(elm.attr('data-target')).toBeDefined();
+    var $modal = $(elm.attr('data-target'));
     expect($modal.hasClass('modal')).toBe(true);
     expect($modal.html()).toBe(scope.modal);
   });
 
   it('should handle extra attributes', function () {
     var elm = compileDirective('extra');
-    var $modal = $(elm.attr('href'));
+    var $modal = $(elm.attr('data-target'));
     // expect($modal.attr('data-backdrop')).toBe('0');
     // expect($modal.attr('data-keyboard')).toBe('0');
     expect($modal.hasClass('modal-wide')).toBe(true);
@@ -63,8 +63,8 @@ describe('modal', function () {
     compileDirective('cached', true);
     expect(scope.$$asyncQueue.length).toBe(0);
     var elm = $('a[bs-modal]');
-    expect(elm.attr('href')).toBeDefined();
-    var $modal = $(elm.attr('href'));
+    expect(elm.attr('data-target')).toBeDefined();
+    var $modal = $(elm.attr('data-target'));
     expect($modal.hasClass('modal')).toBe(true);
     expect($modal.html()).toBe(scope.modal);
   });
@@ -79,14 +79,14 @@ describe('modal', function () {
 
   it('should resolve scope variables in the external partial', function() {
     var elm = compileDirective();
-    var $modal = $(elm.attr('href'));
+    var $modal = $(elm.attr('data-target'));
     $modal.modal('show'); $timeout.flush();
     expect($modal.text()).toBe('Hello ' + scope.content.replace(/<br \/>/g, ''));
   });
 
   it('should show the modal on click', function(/*done*/) {
     var elm = compileDirective();
-    var $modal = $(elm.attr('href'));
+    var $modal = $(elm.attr('data-target'));
     expect($modal.hasClass('hide')).toBe(true);
     elm.trigger('click');
     /*setTimeout(function() {
@@ -102,7 +102,7 @@ describe('modal', function () {
 
     beforeEach(function() {
       elm = compileDirective();
-      $modal = $(elm.attr('href'));
+      $modal = $(elm.attr('data-target'));
       spy = jasmine.createSpy('event');
     });
 


### PR DESCRIPTION
Only in e2e test with Firefox, when the element with directive bsModal is clicked, the browser navigate to the href which is used to store the modal id. 

This issue break the behaviour of the elements inside the modal because there is no controller binded to this specific url...

Using 'data-target' instead of 'href' to target the modal fix this behaviour.
