### PR TITLE
datepicker $render with $viewValue

### DIFF
--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -79,7 +79,7 @@ angular.module('$strap.directives')
 
         // ngModel rendering
         controller.$render = function ngModelRender() {
-          return controller.$modelValue && element.datepicker('update', controller.$modelValue);
+          return controller.$viewValue && element.datepicker('update', controller.$viewValue);
         };
 
       }


### PR DESCRIPTION
I'm not sure this is as simple as my Pull Request suggest, but I just updated Angular Strap on my project wich use another directive to convert the date on the equivalent timestamp (long) by adding a formatter to the ngModelController.

With controller.$modelValue, my formatter was ignored, with $viewValue, it's working fine.

A better solution will be to add native support of type number, I'll make another pull request if I find the time...
