### PR TITLE
Use given scope in $modal directive

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -8,7 +8,7 @@ angular.module('$strap.directives')
     function Modal(options) {
       if(!options) options = {};
 
-      var scope = options.scope ? options.scope.$new() : $rootScope.$new(),
+      var scope = options.scope ? options.scope : $rootScope.$new(),
           templateUrl = options.template;
 
       //@todo support {title, content} object


### PR DESCRIPTION
Don't create a new scope in the $modal directive if a scope was defined in the options object.
