### PR TITLE
Use keyboard and backdrop properties in Bootstrap Modal

### DIFF
--- a/src/directives/modal.js
+++ b/src/directives/modal.js
@@ -20,8 +20,8 @@ angular.module('$strap.directives')
         var id = templateUrl.replace('.html', '').replace(/[\/|\.|:]/g, '-') + '-' + scope.$id;
         var $modal = $('<div class="modal hide" tabindex="-1"></div>').attr('id', id).addClass('fade').html(template);
 
-        if(options.backdrop !== undefined) $modal.data("backdrop", options.backdrop);
-        if(options.keyboard !== undefined) $modal.data("keyboard", options.keyboard);
+        if(options.backdrop !== undefined) $modal.data('backdrop', options.backdrop);
+        if(options.keyboard !== undefined) $modal.data('keyboard', options.keyboard);
         if(options.modalClass) $modal.addClass(options.modalClass);
 
         $('body').append($modal);


### PR DESCRIPTION
The keyboard and backdrop options were never passed as data attributes to the `<div class="modal" />`
