### PR TITLE
Improved efficiency of buttonSelect.js

### DIFF
--- a/src/directives/buttonSelect.js
+++ b/src/directives/buttonSelect.js
@@ -16,8 +16,8 @@ angular.module('$strap.directives')
       if(ctrl) {
         element.text(scope.$eval(attrs.ngModel));
         // Watch model for changes
-        scope.$watch(attrs.ngModel, function(newValue, oldValue) {
-          element.text(newValue);
+        attrs.$observe('ngModel', function(value) {
+          element.text(scope.$eval(value));
         });
       }
 


### PR DESCRIPTION
The [Angular docs](http://docs.angularjs.org/guide/directive#attributes) mention that `attrs.$observe` is more efficient than `scope.$watch`:

> _observing interpolated attributes_: Use $observe to observe the value changes of attributes that contain interpolation (e.g. src="{{bar}}"). Not only is this very efficient but it's also the only way to easily get the actual value because during the linking phase the interpolation hasn't been evaluated yet and so the value is at this time set to undefined.

I rewrote the watcher in `buttonSelect.js` so that it makes use of it instead.
