### PR TITLE
fix(select): Fix to work with async changes to menu items

### DIFF
--- a/src/directives/select.js
+++ b/src/directives/select.js
@@ -13,9 +13,13 @@ angular.module('$strap.directives')
 
       var options = scope.$eval(attrs.bsSelect) || {};
 
-      $timeout(function() {
-        element.selectpicker(options);
-        element.next().removeClass('ng-scope');
+      element.selectpicker(options);
+      element.next().removeClass('ng-scope');
+
+      scope.$watch(function () {
+        return element[0].length;
+      }, function () {
+        element.selectpicker('refresh');
       });
 
       // If we have a controller (i.e. ngModelController) then wire it up

--- a/test/unit/directives/selectSpec.js
+++ b/test/unit/directives/selectSpec.js
@@ -2,15 +2,13 @@
 // global describe, it
 
 describe('select', function () {
-  var scope, $sandbox, $compile, $timeout, $httpBackend, $templateCache;
+  var scope, $sandbox, $compile, $templateCache;
 
   beforeEach(module('$strap.directives'));
 
-  beforeEach(inject(function ($injector, $rootScope, _$compile_, _$timeout_, _$httpBackend_, _$templateCache_) {
+  beforeEach(inject(function ($injector, $rootScope, _$compile_, _$templateCache_) {
     scope = $rootScope;
     $compile = _$compile_;
-    $timeout = _$timeout_;
-    $httpBackend = _$httpBackend_;
     $templateCache = _$templateCache_;
 
     $sandbox = $('<div id="sandbox"></div>').appendTo('body');
@@ -34,7 +32,6 @@ describe('select', function () {
     var $element = $(template.element).appendTo($sandbox);
     $element = $compile($element)(scope);
     scope.$digest(); // evaluate $evalAsync queue used by $q
-    $timeout.flush();
     return $element;
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/mgcrea/angular-strap/pull/85 the field is not being updated when model used by ng-options is updated.

I am using this directive with a ng-options content fetched by $http and the bootstrap-select field never refreshes.

I have no idea why the test regarding this is passing with the existing implementation. From reading the code it looks like it wouldn't and from experimenting with console log I can see that the refresh is never called on the object after the model is updated. Consequently I couldn't find a way to capture this bug for a new test.
