### PR TITLE
Fixed datepicker.js to use data-date-* attributes correctly

### DIFF
--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -53,9 +53,24 @@ angular.module('$strap.directives')
           type = attrs.dateType || options.type || 'date';
 
       // $.fn.datepicker options
-      angular.forEach(['format', 'weekStart', 'calendarWeeks', 'startDate', 'endDate', 'daysOfWeekDisabled', 'autoclose', 'startView', 'minViewMode', 'todayBtn', 'todayHighlight', 'keyboardNavigation', 'language', 'forceParse'], function(key) {
-        if(angular.isDefined(attrs[key])) options[key] = attrs[key];
-      });
+      angular.forEach([
+          ['format', 'dateFormat'],
+          ['weekStart', 'dateWeekStart'],
+          ['calendarWeeks', 'dateCalendarWeeks'],
+          ['startDate', 'dateStartDate'],
+          ['endDate', 'dateEndDate'],
+          ['daysOfWeekDisabled', 'dateDaysOfWeekDisabled'],
+          ['autoclose', 'dateAutoclose'],
+          ['startView', 'dateStartView'],
+          ['minViewMode', 'dateMinViewMode'],
+          ['todayBtn', 'dateTodayBtn'],
+          ['todayHighlight', 'dateTodayHighlight'],
+          ['keyboardNavigation', 'dateKeyboardNavigation'],
+          ['language', 'dateLanguage'],
+          ['forceParse', 'dateForceParse']
+        ], function (key) {
+          if (angular.isDefined(attrs[key[1]])) options[key[0]] = attrs[key[1]];
+        });
 
       var language = options.language || 'en',
           readFormat = attrs.dateFormat || options.format || ($.fn.datepicker.dates[language] && $.fn.datepicker.dates[language].format) || 'mm/dd/yyyy',


### PR DESCRIPTION
Angular-strap was not using data-date-\* attributes correctly because the attrs[] array has different keys than the options[] array.  I couldn't simply using attrs['date' + key] because of the camel casing.

This is a simple fix to make it work without parsing anything.
