### PR TITLE
Auto-collapse when item is selected.

### DIFF
--- a/src/directives/navbar.js
+++ b/src/directives/navbar.js
@@ -19,7 +19,7 @@ angular.module('$strap.directives')
             regexp = new RegExp('^' + pattern + '$', ['i']);
 
           if(regexp.test(newValue)) {
-            $li.addClass('active').find('.collapse').collapse('hide');
+            $li.addClass('active').find('.collapse.in').collapse('hide');
           } else {
             $li.removeClass('active');
           }


### PR DESCRIPTION
On touch devices, when an item in the collapse is clicked, the menu stays. This change makes it hide
