### PR TITLE
Fix setStartDate and endStartDate

### DIFF
--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -135,14 +135,18 @@ angular.module('$strap.directives')
 
         // Update start-date when changed
         attrs.$observe('startDate', function(value) {
-          value = value.replace(/(^")|("$)/g, '');
-          element.datepicker('setStartDate',new Date(value));
+          if (!angular.isUndefined(value)) {
+            value = value.replace(/(^")|("$)/g, '');
+            element.datepicker('setStartDate',new Date(value));
+          }
         });
 
         // Update end-date when changed
         attrs.$observe('endDate', function(value) {
-          value = value.replace(/(^")|("$)/g, '');
-          element.datepicker('setEndDate',new Date(value));
+          if (!angular.isUndefined(value)) {
+            value = value.replace(/(^")|("$)/g, '');
+            element.datepicker('setEndDate',new Date(value));
+          }
         });
 
       }


### PR DESCRIPTION
For some reason the attrs.$observe is adding quotes around the value parameter making the string ""date"" instead of "date". Also added in passing Date objects instead of strings.
