### PR TITLE
added possibilities to have icons in dropdown list

### DIFF
--- a/src/directives/dropdown.js
+++ b/src/directives/dropdown.js
@@ -10,6 +10,7 @@ angular.module('$strap.directives')
       if(item.divider) return ul.splice(index + 1, 0, '<li class="divider"></li>');
       var li = '<li' + (item.submenu && item.submenu.length ? ' class="dropdown-submenu"' : '') + '>' +
         '<a tabindex="-1" ng-href="' + (item.href || '') + '"' + (item.click ? '" ng-click="' + item.click + '"' : '') + (item.target ? '" target="' + item.target + '"' : '') + (item.method ? '" data-method="' + item.method + '"' : '') + '>' +
+        (item.icon && '<i class="' + item.icon + '"></i>&nbsp;' || '') +
         (item.text || '') + '</a>';
       if(item.submenu && item.submenu.length) li += buildTemplate(item.submenu).join('\n');
       li += '</li>';


### PR DESCRIPTION
I had the possibilities the specified a bootstrap icon in the javascript object. Instead of concatenate it to the text.

e.g.

$scope.dropdown: [
  {
    "text": "Another action",
    "href": "#anotherAction"
    "icon": "icon-check" 
  }]
