### PR TITLE
Added element id (or element var) to typeahread-updated emit

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -32,7 +32,7 @@ angular.module('$strap.directives')
               controller.$setViewValue(value);
             });
           }
-          scope.$emit('typeahead-updated', value);
+          scope.$emit('typeahead-updated', value, attrs.id);
           return value;
         }
       });


### PR DESCRIPTION
When emitting the change event on the typeahead add the id of the element or element itself to the emit so the element that was updated can be identified when handling the emit.  This helps when there are multiple typeaheads on a page with different actions when the values are changed.
