### PR TITLE
Added support for popover placement and trigger attributes

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -34,6 +34,13 @@ angular.module('$strap.directives')
           template = template.data;
         }
 
+        // Handle data-placement and data-trigger attributes
+        angular.forEach(['placement', 'trigger'], function(name) {
+          if(!!attr[name]) {
+            options[name] = attr[name];
+          }
+        });
+
         // Handle data-unique attribute
         if(!!attr.unique) {
           element.on('show', function(ev) { // requires bootstrap 2.3.0+

--- a/test/unit/directives/popoverSpec.js
+++ b/test/unit/directives/popoverSpec.js
@@ -53,6 +53,16 @@ describe('popover', function () {
       scope: {things: [{name: "A"}, {name: "B"}, {name: "C"}]},
       popover: '<ul><li ng-repeat="thing in things">{{thing.name}}</li></ul>',
       element: '<a class="btn" bs-popover="\'partials/popover.html\'"></a>'
+    },
+    'placement': {
+      scope: {content: "World<br />Multiline Content<br />"},
+      popover: 'Hello <span ng-bind-html-unsafe="content"></span>',
+      element: '<a class="btn" bs-popover="\'partials/popover.html\'" data-title="aTitle" data-placement="right"></a>'
+    },
+    'trigger': {
+      scope: {content: "World<br />Multiline Content<br />"},
+      popover: 'Hello <span ng-bind-html-unsafe="content"></span>',
+      element: '<a class="btn" bs-popover="\'partials/popover.html\'" data-title="aTitle" data-trigger="hover"></a>'
     }
   };
 
@@ -101,6 +111,20 @@ describe('popover', function () {
     var elm = compileDirective();
     elm.popover('show');
     expect(elm.data('popover').tip().find('.popover-title').text()).toBe('aTitle');
+  });
+
+  it('should define a correct trigger', function() {
+    var elm = compileDirective('trigger');
+    elm.trigger('mouseover');
+    expect(elm.data('popover').tip().hasClass('in')).toBe(true);
+    elm.trigger('mouseleave');
+    expect(elm.data('popover').tip().hasClass('in')).toBe(false);
+  });
+
+  it('should define a correct placement', function() {
+    var elm = compileDirective('placement');
+    elm.popover('show');
+    expect(elm.data('popover').tip().hasClass('right')).toBe(true);
   });
 
   it('should resolve scope variables in the external partial', function() {


### PR DESCRIPTION
Added support for the bootstrap data-placement and data-trigger attributes. Now users can have popovers appear top, right, left, and bottom. Trigger allows popovers to appear by hover, click, focus, and manual events.
