### PR TITLE
Avoid recreating the picker control while the dropdown is open.

### DIFF
--- a/src/directives/select.js
+++ b/src/directives/select.js
@@ -24,6 +24,11 @@ angular.module('$strap.directives')
         // Watch for changes to the model value
         scope.$watch(attrs.ngModel, function(newValue, oldValue) {
           if (!angular.equals(newValue, oldValue)) {
+            // Avoid closing the dropdown while selecting multiple options
+            if (element.attr('multiple') &&
+                element.data().selectpicker.button.parent().hasClass('open'))
+              return true;
+            
             element.selectpicker('refresh');
           }
         });


### PR DESCRIPTION
The original boostrap-select keeps menu options open when the control has the `multiple` attribute. This helps users to select multiple values without re-opening the options menu.

Current implementation of angular-strap closes the menu after an option is selected. This pool request avoid recreating the picker while the dropdown options are shown.
