### PR TITLE
Fix for digest already in progress

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -54,7 +54,9 @@ angular.module('$strap.directives')
             if(!!newValue) {
               popover.hide();
             } else if(newValue !== oldValue) {
-              popover.show();
+              $timeout(function() {
+                popover.show();
+              });
             }
           });
         }


### PR DESCRIPTION
This is similar to https://github.com/mgcrea/angular-strap/commit/3c8bd1d37ab3b023bd79f9b0c1a6931b18e2ac84#L0R65

In that revision data-show uses $timeout but data-hide still doesn't so if you use data-hide="false" then you will get "$digest already in progress".

Below is plunker with applied fix:
http://plnkr.co/edit/cxLCKtxDb2peqaaMqQui?p=preview

If you want to reproduce problem then:
1. In plunker change url
from: "//rawgithub.com/arvenil/angular-strap/fix_for_digest_already_in_progress/dist/angular-strap.js"
to: "//rawgithub.com/mgcrea/angular-strap/v0.7.5/dist/angular-strap.js"
2. Click on any button
3. Popover should show but it doesn't
4. Look into error log console to see "$digest already in progress"
