### PR TITLE
fix(select): handle changes to the option items

### DIFF
--- a/src/directives/select.js
+++ b/src/directives/select.js
@@ -17,15 +17,24 @@ angular.module('$strap.directives')
         element.selectpicker(options);
         element.next().removeClass('ng-scope');
       });
-
+      
       // If we have a controller (i.e. ngModelController) then wire it up
       if(controller) {
 
-        // Watch for changes to the model value
-        scope.$watch(attrs.ngModel, function(newValue, oldValue) {
+        var refresh = function(newValue, oldValue) {
           if (!angular.equals(newValue, oldValue)) {
             element.selectpicker('refresh');
           }
+        };
+
+        // Watch for changes to the model value
+        scope.$watch(attrs.ngModel, function(newValue, oldValue) {
+          refresh(newValue, oldValue);
+        });
+
+        // Watch for changes to the options
+        scope.$watch(attrs.bsSelect, function(newValue, oldValue) {
+          refresh(newValue, oldValue);
         });
 
       }

--- a/test/unit/directives/selectSpec.js
+++ b/test/unit/directives/selectSpec.js
@@ -24,7 +24,7 @@ describe('select', function () {
   var templates = {
     'default': {
       scope: {items: [{id: '1', name: 'foo'}, {id: '2', name: 'bar'}, {id: '3', name: 'baz'}], selectedItem: '2'},
-      element: '<select ng-model="selectedItem" ng-options="value.id as value.name for (key, value) in items" bs-select></select>'
+      element: '<select ng-model="selectedItem" ng-options="value.id as value.name for (key, value) in items" bs-select="items"></select>'
     }
   };
 
@@ -78,6 +78,13 @@ describe('select', function () {
 
     it('does not add ng-scope class to bootstrap select element', function () {
       expect(select.hasClass('ng-scope')).toBe(false);
+    });
+
+    it('updates bootstrap select when the option items change', function () {
+      scope.items.push({id: '4', name: 'shock'});
+      scope.selectedItem = '4';
+      scope.$digest();
+      expect(menu.find('.selected').text()).toBe('shock');
     });
 
     // it('adds new classes from original element when the model changes', function () {


### PR DESCRIPTION
If the option items change the `directive` should refresh the `selectpicker`. The behaviour is now
handled if the user sets the `bs-select` property to the options array (the one that is also set in the
`ng-options`).
The directive already used to do `scope.$eval(attrs.bsSelect)` but then did nothing with it.
A `refresh` local function has been added not to replicate the same code of testing new and old
values and then refreshing the `selectpicker`.
A proper test has been added, where an item is pushed into the options array, that same item is
then selected and tested against.

Closes #204.
