### PR TITLE
fix(timepickerSpec): fix testing error on different timezones/languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "karma-chrome-launcher": "~0.1.0",
     "karma-firefox-launcher": "~0.1.0",
     "karma-jasmine": "~0.1.0",
-    "karma-junit-reporter": "~0.1.0"
+    "karma-junit-reporter": "~0.1.0",
+    "source-map": "~0.1.30"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/test/unit/directives/timepickerSpec.js
+++ b/test/unit/directives/timepickerSpec.js
@@ -82,7 +82,7 @@ describe('timepicker', function () {
     elm.data('timepicker').$widget.find('a[data-action="incrementHour"]').trigger('click');
     $timeout.flush();
     expect(elm.val()).toBe('01:00');
-    expect(scope.model.time).toMatch(/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{4} 01:00:\d{2} GMT[-+]\d{4} \([A-Z]{3,4}\)/);
+    expect(scope.model.time).toMatch(/(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{4} 01:00:\d{2} GMT[-+]\d{4} \(.*\)/);
   });
 
   it('should not accept bad input', function() {


### PR DESCRIPTION
When executing the `timepickerSpec` tests, a test failed while matching a RegEx saying:

```
PhantomJS 1.9.2 (Windows 8) timepicker should correctly update both input value
and bound model for date type FAILED
        Expected Date(Tue Oct 01 2013 01:00:04 GMT+0200 (ora legale Europa occid
entale)) to match /(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Au
g|Sep|Oct|Nov|Dec) \d{1,2} \d{4} 01:00:\d{2} GMT[-+]\d{4} \([A-Z]{3,4}\)/.
```

The latest part of the string (`ora legale Europa occidentale`) didn't match the `[A-Z]{3,4}` RegEx part, so it had to be changed for the tests to succeed (please see http://gskinner.com/RegExr/?36i47 for a RegEx test).
Also, after calling `grunt test`, `grunt` complained about `source-map` missing, so it was added to the `devDependencies`.
