### PR TITLE
Fixed tooltip directive for BS 2 to 3 change.

### DIFF
--- a/src/directives/tooltip.js
+++ b/src/directives/tooltip.js
@@ -23,7 +23,7 @@ angular.module('$strap.directives')
           // Hide any active popover except self
           $('.tooltip.in').each(function() {
             var $this = $(this),
-              tooltip = $this.data('tooltip');
+              tooltip = $this.data('bs.tooltip');
             if(tooltip && !tooltip.$element.is(element)) {
               $this.tooltip('hide');
             }
@@ -38,11 +38,11 @@ angular.module('$strap.directives')
       });
 
       // Bootstrap override to provide events & tip() reference
-      var tooltip = element.data('tooltip');
+      var tooltip = element.data('bs.tooltip');
       tooltip.show = function() {
         var r = $.fn.tooltip.Constructor.prototype.show.apply(this, arguments);
         // Bind tooltip to the tip()
-        this.tip().data('tooltip', this);
+        this.tip().data('bs.tooltip', this);
         return r;
       };
 


### PR DESCRIPTION
Since Bootstrap v3.0 the tooltip stores its data in a 'bs.' prefixed data attribute.

Without this change, Chrome console reports issue:

```
TypeError: Cannot set property 'show' of undefined
    at postLink ([...]/angular-strap.js:800:22)
```

See line differences:
https://github.com/twbs/bootstrap/blob/v3.0.0/js/tooltip.js#L367
https://github.com/twbs/bootstrap/blob/v2.3.2/js/bootstrap-tooltip.js#L331
