### PR TITLE
fix the memory leak when the content contain directive with isolated scope

### DIFF
--- a/src/directives/popover.js
+++ b/src/directives/popover.js
@@ -86,8 +86,7 @@ angular.module('$strap.directives')
         };
         popover.getPosition = function() {
           var r = $.fn.popover.Constructor.prototype.getPosition.apply(this, arguments);
-          // create new scope to compile against
-          popoverScope = scope.$new();
+
           // Compile content
           $compile(this.$tip)(popoverScope);
           scope.$digest();
@@ -119,7 +118,10 @@ angular.module('$strap.directives')
         scope.$on('popover-hidden',function(){
           $timeout(function(){
             popoverScope.$destroy();
-          },0);
+          });
+        });
+        scope.$on('popover-show',function(){
+            popoverScope = scope.$new();
         });
 
       });


### PR DESCRIPTION
1. create new child scope from the given one
2. destroy the child scope when the popover is hidden

when the content contain template with directive with isolated scope, the scope is not destroyed.

for example:

var popoverOptions = {
  "content": "HTML_WITH_DIRECTIVE_WITH_ISOLATED_SCOPE",
  ...
}

each time the popover is shown new scope is created and the old one is not destroyed.
