### PR TITLE
Avoid call to $apply to improve performance

### DIFF
--- a/src/directives/button.js
+++ b/src/directives/button.js
@@ -137,7 +137,7 @@ angular.module('$strap.directives')
               .find('[value]').button()
               .filter('[value="' + controller.$viewValue + '"]')
               .addClass('active');
-          });
+          }, 0, false);
 
           iElement.on('click.button.data-api', function (ev) {
             scope.$apply(function () {


### PR DESCRIPTION
The function does not change the model so we can prevent $timeout to do the $apply. The performance improvement is very noticeable with a lot of instances of the directive (+30)
