### PR TITLE
Adds element to typeahead callback function arguments

### DIFF
--- a/src/directives/typeahead.js
+++ b/src/directives/typeahead.js
@@ -46,7 +46,7 @@ angular.module('$strap.directives')
         if (this.query.length < this.options.minLength) {
           return this.shown ? this.hide() : this;
         }
-        items = $.isFunction(this.source) ? this.source(this.query, $.proxy(this.process, this)) : this.source;
+        items = $.isFunction(this.source) ? this.source(this.query, this.$element, $.proxy(this.process, this)) : this.source;
         return items ? this.process(items) : this;
       };
 


### PR DESCRIPTION
Offers a way to use the same callback function for multiple elements.

Usage example:

View

``` html
<input name="brands" type="text" bs-typeahead="typeaheadFn" />
<input name="models" type="text" bs-typeahead="typeaheadFn" />
```

Controller

``` javascript
$scope.brands = {"brands":[{"label":"ALFA ROMEO"},{"label":"AUDI"}]};
$scope.models = {"models":[{"label":"Mito"},{"label":"A 1"}]};

$scope.typeaheadFn = function(query, element) {
    return $.map($scope[element[0].name], function(e) {
        return e.label;
    });
}
```
