### PR TITLE
Tab flapping fix

### DIFF
--- a/src/directives/tab.js
+++ b/src/directives/tab.js
@@ -79,9 +79,11 @@ angular.module('$strap.directives')
             if(angular.isUndefined(newValue)) return;
             activeTab = newValue; // update starting activeTab before first build
             setTimeout(function() {
-              var $next = $($tabs[0].querySelectorAll('li')[newValue*1]);
-              if(!$next.hasClass('active')) {
-                $next.children('a').tab('show');
+              if(activeTab === newValue) {
+                var $next = $($tabs[0].querySelectorAll('li')[newValue*1]);
+                if(!$next.hasClass('active')) {
+                  $next.children('a').tab('show');
+                }
               }
             });
           });


### PR DESCRIPTION
If the model is rapidly updated while the browser is under load it is possible for activeTab to be assigned a new value before the code within the setTimeout executes. 

This can cause the interface to switch back and forth between tabs in an uncontrolled manner. This code simply checks if activeTab is still what we expect it to be before making the change
