### PR TITLE
Fixing redundant select picker refresh

### DIFF
--- a/src/directives/select.js
+++ b/src/directives/select.js
@@ -26,7 +26,9 @@ angular.module('$strap.directives')
 
         var refresh = function(newValue, oldValue) {
           if (!angular.equals(newValue, oldValue)) {
-            element.selectpicker('refresh');
+            $timeout(function () {
+              element.selectpicker('refresh');
+            });
           }
         };
         
@@ -53,7 +55,11 @@ angular.module('$strap.directives')
         });
 
         // Watch for changes to the model value
-        scope.$watch(attrs.ngModel, refresh);
+        scope.$watch(attrs.ngModel, function (newValue, oldValue) {
+          if (!selectpicker.find(document.activeElement)[0]) {
+            refresh(newValue, oldValue);
+          }
+        });
 
         // Watch for changes to the options
         if (attrs.ngOptions) {


### PR DESCRIPTION
This issue relates to pull request: https://github.com/mgcrea/angular-strap/pull/246.  

In the select directive, the watch on selected items (ngModel) is firing a select picker refresh when the selected item(s) has changed from a UI event.  The selected item has already been decorated and the UI does not need to be refreshed.

The watch has been changed to check if the document active element is a child of the select picker and skips the select picker refresh accordingly.

I also wrapped the element.selectpicker('refresh') in the refresh function in a $timeout function as it wasn't picking up changes made to the options (tested with 50+ options).

The select tests are now failing and I'm not sure how to fix that.
