### PR TITLE
Fix $digest already in progress on scope.$apply datepicker

### DIFF
--- a/src/directives/datepicker.js
+++ b/src/directives/datepicker.js
@@ -50,7 +50,6 @@ angular.module('$strap.directives')
 
   return {
     restrict: 'A',
-    require: '?ngModel',
     link: function postLink(scope, element, attrs, controller) {
 
       var options = angular.extend({autoclose: true}, $strapConfig.datepicker || {});


### PR DESCRIPTION
Removed the require property to fix the $digest already in progress error that occurs when ng-model is set on an element that has a directive which requires ngModel. Issue was also raised on pull request 308:

https://github.com/mgcrea/angular-strap/pull/308
