### PR TITLE
fix(datepicker): remove the Date.UTC to generate the title of the datepicker

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -453,7 +453,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.tooltip'])
             },
             build: function() {
               var days = [], day;
-              var firstDayOfMonth = new Date(Date.UTC(viewDate.year, viewDate.month, 1));
+              var firstDayOfMonth = new Date(viewDate.year, viewDate.month, 1);
               var firstDate = new Date(+firstDayOfMonth - (firstDayOfMonth.getUTCDay() + 1 - options.weekStart) * 864e5);
               // lastDate = new Date(Date.UTC(firstDate.getUTCFullYear(), firstDate.getUTCMonth(), firstDate.getUTCDate() + 1, 0, 0, 0, -1));
               for(var i = 0; i < 35; i++) {
@@ -500,7 +500,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.tooltip'])
             build: function() {
               var months = [], month;
               for (var i = 0; i < 12; i++) {
-                month = new Date(Date.UTC(viewDate.year, i, 1));
+                month = new Date(viewDate.year, i, 1);
                 months.push({date: month, label: dateFilter(month, this.format), selected: picker.$isSelected(month), disabled: this.isDisabled(month)});
               }
               scope.title = dateFilter(month, 'yyyy');
@@ -544,7 +544,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.tooltip'])
               var firstYear = viewDate.year - viewDate.year % (this.split * 3);
               var years = [], year;
               for (var i = 0; i < 12; i++) {
-                year = new Date(Date.UTC(firstYear + i, 0, 1));
+                year = new Date(firstYear + i, 0, 1);
                 years.push({date: year, label: dateFilter(year, this.format), selected: picker.$isSelected(year), disabled: this.isDisabled(year)});
               }
               scope.title = years[0].label + '-' + years[years.length - 1].label;


### PR DESCRIPTION
Currently the datepicker does not show the correct title.

For example, I'm in EST timezone. My input date is January 2014. When I open the datepicker, the firstDayOfMonth  variable will be 2014-01-01 UTC. So converted to EST will display december 2013 in my title bar because it's using Dec 31 2013 19:00:00.

Same issue apply when selecting a month. For example June will display one month difference.

When you reach the year to select on the title, it will also selected the year before the one you choose.

This fix should work depending your timezone.
Thx for this awesome library.
