### PR TITLE
fix(typeahead): don't throw ReferenceError when viewValue is undefined

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -198,4 +198,13 @@ describe('typeahead', function () {
 
   });
 
+
+  describe('$isVisible method', function() {
+    it('should not throw when ngModel.$viewValue is undefined', function() {
+      scope.items = [ "one", "two", "three" ];
+      var element = $compile('<input type="text" class="form-control" ng-model="selected" data-min-length="0" data-html="1" ng-options="item as item for item in items" bs-typeahead>')(scope);
+      scope.$digest();
+      expect(scope.$$childHead.$isVisible).not.toThrow();
+    });
+  });
 });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -100,7 +100,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
             return !!scope.$matches.length;
           }
           // minLength support
-          return scope.$matches.length && controller.$viewValue.length >= options.minLength;
+          return scope.$matches.length && typeof controller.$viewValue === 'string' && controller.$viewValue.length >= options.minLength;
         };
 
         $typeahead.$onMouseDown = function(evt) {


### PR DESCRIPTION
When the typeahead's model value isn't initialized somewhere, the $isVisible method would throw because ngModel.$viewValue is undefined. This change will consider the value to be below the min length if the view value is undefined.

---

Feel free to re-organize the test or adjust style or whatever. As far as I can tell, typeahead is the only module affected by this, since there's no way to set the minLength option with the bs-select directive. The datepicker might also be affected, though.
