### PR TITLE
$sce - always escape strict context

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -91,7 +91,7 @@ angular.module('mgcrea.ngStrap.alert', [])
         // Support scope as data-attrs
         angular.forEach(['title', 'content', 'type'], function(key) {
           attr[key] && attr.$observe(key, function(newValue, oldValue) {
-            scope[key] = newValue;
+            scope[key] = $sce.getTrustedHtml(newValue);
           });
         });
 


### PR DESCRIPTION
Fixes problem with 
[$sce:unsafe] Attempting to use an unsafe value in a safe context.
