### PR TITLE
Fixing Compile Error

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -97,16 +97,14 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           $modal.init();
         });
 
-        $modal.init = function() {
-
-          // Options: show
-          if(options.show) {
-            scope.$$postDigest(function() {
-              options.trigger === 'focus' ? element[0].focus() : $modal.show();
-            });
-          }
-
-        };
+       $modal.init = function () {
+          	var element = element || undefined;
+            if (options.show) {
+              scope.$$postDigest(function () {
+                options.trigger === 'focus' && element ? element[0].focus() : $modal.show();
+              });
+            }
+          };
 
         $modal.destroy = function() {
 


### PR DESCRIPTION
In certain compilers ie: Google Closure, will throw an error in thrown during attempt to compile code because element is not declared. The above fix with declare element unto itselfs or at least declare it as undefined.
