### PR TITLE
move isShown=false before the digest on hide

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -182,8 +182,8 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           if(options.backdrop) {
             $animate.leave(backdropElement, function() {});
           }
-          scope.$$phase || scope.$digest();
           scope.$isShown = false;
+          scope.$$phase || scope.$digest();
 
           // Unbind events
           if(options.backdrop) {


### PR DESCRIPTION
In my opinion, the digest should be run after isShown is set to false, otherwise external watchers will not hear about it.
