### PR TITLE
Fixes #404

### DIFF
--- a/src/tooltip/tooltip.tpl.html
+++ b/src/tooltip/tooltip.tpl.html
@@ -1,4 +1,4 @@
-<div class="tooltip" ng-show="title">
+<div class="tooltip in" ng-show="title">
   <div class="tooltip-arrow"></div>
   <div class="tooltip-inner" ng-bind="title"></div>
 </div>


### PR DESCRIPTION
Fixes this issue #404 normal tooltip disappears,

I also tried to do a grunt build but it seems that it appends the date to all sources, so the diff would be bigger, so I just opted out to just edit the template first.

What happens is that .tooltip in the normal bootstrap has the opacity 0, so what I did is just added a class in so it won't disappear.  Since as I understand you are removing the tooltip in the dom.
