### PR TITLE
fix(TooltipFactory): fix content template for tooltip

### DIFF
--- a/dist/modules/tooltip.js
+++ b/dist/modules/tooltip.js
@@ -76,7 +76,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions']).
             return $q.when($templateCache.get(options.contentTemplate) || $http.get(options.contentTemplate, { cache: $templateCache })).then(function (contentTemplate) {
               if (angular.isObject(contentTemplate))
                 contentTemplate = contentTemplate.data;
-              findElement('[ng-bind="content"]', templateEl[0]).removeAttr('ng-bind').html(contentTemplate);
+              findElement('[ng-bind="title"]', templateEl[0]).removeAttr('ng-bind').html(contentTemplate);
               return templateEl[0].outerHTML;
             });
           });


### PR DESCRIPTION
The tooltip contenttempalte is looking for [ng-bind="content"] instead of [ng-bind="title"].  This commit fixes that.

fixes #407
