### PR TITLE
fix(TooltipFactory): fix content template for tooltip

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -80,7 +80,10 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             return $q.when($templateCache.get(options.contentTemplate) || $http.get(options.contentTemplate, {cache: $templateCache}))
             .then(function(contentTemplate) {
               if(angular.isObject(contentTemplate)) contentTemplate = contentTemplate.data;
-              findElement('[ng-bind="content"]', templateEl[0]).removeAttr('ng-bind').html(contentTemplate);
+              if (findElement('[ng-bind="title"]', templateEl[0]).length)
+								findElement('[ng-bind="title"]', templateEl[0]).removeAttr('ng-bind').html(contentTemplate);
+							else
+								findElement('[ng-bind="content"]', templateEl[0]).removeAttr('ng-bind').html(contentTemplate);
               return templateEl[0].outerHTML;
             });
           });


### PR DESCRIPTION
The tooltip contenttempalte is looking for [ng-bind="content"] instead of [ng-bind="title"].  This commit fixes that.  This is my second take, I added a condition to look for ng-bind title first then reverts to content if not.

fixes #407
