### PR TITLE
fix for misplaced close button on Bootstrap v3.1.0

### DIFF
--- a/src/alert/alert.tpl.html
+++ b/src/alert/alert.tpl.html
@@ -1,4 +1,4 @@
-<div class="alert" tabindex="-1" ng-class="[type ? 'alert-' + type : null]">
+<div class="alert alert-dismissable" tabindex="-1" ng-class="[type ? 'alert-' + type : null]">
   <button type="button" class="close" ng-click="$hide()">&times;</button>
   <strong ng-bind="title"></strong>&nbsp;<span ng-bind-html="content"></span>
 </div>


### PR DESCRIPTION
on Bootstrap v3.1.0 close button missplaces. Adding

```
.alert-dismissable
```

to the wrapper div solves this issue.
