### PR TITLE
docs : tooltip functions do not begins with a $

### DIFF
--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -166,13 +166,13 @@
   <h3>Scope methods</h3>
   <p>Methods available inside the directive scope to toggle visibility.</p>
 
-  <h4>$show()</h4>
+  <h4>show()</h4>
   <p>Reveals the tooltip.</p>
 
-  <h4>$hide()</h4>
+  <h4>hide()</h4>
   <p>Hides the tooltip.</p>
 
-  <h4>$toggle()</h4>
+  <h4>toggle()</h4>
   <p>Toggles the tooltip.</p>
 
 </div>


### PR DESCRIPTION
Hello, 
I found out that the documentation didn't represent the state of the code properly. tooltip functions :show, hideand toggle do not starts with a '$'.

Since the tests also assume there is no '$', I decided to change the documentation instead of the code (and add a '$').
