### PR TITLE
fix($tooltip) : Call to $tooltip.hide cause an error.

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -132,6 +132,13 @@ describe('tooltip', function() {
       expect(bodyEl.children('.tooltip').length).toBe(0);
     });
 
+    it('should do nothing when hiding an already hidden popup', function() {
+      var myTooltip = $tooltip(sandboxEl, templates['default'].scope.tooltip);
+      scope.$digest();
+      myTooltip.hide();
+      expect(bodyEl.children('.tooltip').length).toBe(0);
+    });
+
     it('should correctly be destroyed', function() {
       var myTooltip = $tooltip(sandboxEl, templates['default'].scope.tooltip);
       scope.$digest();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -224,6 +224,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $tooltip.hide = function(blur) {
 
+          if(!$tooltip.$isShown) return; //Do nothing if the tooltip is not shown
+
           $animate.leave(tipElement, function() {
             tipElement = null;
           });


### PR DESCRIPTION
Call to $tooltip.hide causes an error when the tooltip is already hidden .User should not have to check if a tooltip is shown before calling $tooltip.hide, it should simply be a noop.

I've added a simple test to verify that a call to $tooltip.hide on a hidden tooltip doesn't throw a TypeError.
