### PR TITLE
feat(typeahead): set model value on scope

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -175,6 +175,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Watch model for changes
         scope.$watch(attr.ngModel, function(newValue, oldValue) {
+          scope.$modelValue = newValue; //Set model value on the scope to custom templates can use it.
           parsedOptions.valuesFn(scope, controller)
           .then(function(values) {
             if(values.length > limit) values = values.slice(0, limit);


### PR DESCRIPTION
Set the model value that the typeahead is connected to on the scope so that custom data-templates can use it.

Example use case would be to highlight the text that is searched for in the template
