### PR TITLE
Add firing of events to notify about modal show/hide.

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -159,7 +159,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           if(options.keyboard) {
             modalElement.on('keyup', $modal.$onKeyUp);
           }
-
+          
+          // Fire show event up the scope tree
+          scope.$emit('modal.show', $modal);
         };
 
         $modal.hide = function() {
@@ -184,7 +186,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           if(options.keyboard) {
             modalElement.off('keyup', $modal.$onKeyUp);
           }
-
+          
+          // Fire hide event up the scope tree
+          scope.$emit('modal.hide', $modal);
         };
 
         $modal.toggle = function() {


### PR DESCRIPTION
The modal component (among others) needs a way to tell other component that it has been closed/opened. This is very important for use-cases where we depend on the input given in the modal (i.e. via forms). If the user closes the modal before/after entering data, we need an easy way to catch this.

After this change, it's possible to do:

``` js
scope.$on('modal.show', function(){
  // The modal has been shown to the user, load remote data, prepare other listeners etc.
});

scope.$on('modal.hide', function(){
  // The modal has been closed by the user... do something
});
```
