### PR TITLE
fix(gitignore): un-ignore dist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 /docs/
 /test/coverage/
 !.gitignore
+!dist/


### PR DESCRIPTION
Always include dist directory regardless of parent .gitignore. For example Yeoman projects ignore it by default.
