### PR TITLE
Tooltip/Popover 'element.on is not a function' fix

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -112,9 +112,9 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
           // Options: trigger
           var triggers = options.trigger.split(' ');
           angular.forEach(triggers, function(trigger) {
-            if(trigger === 'click') {
+            if(trigger === 'click' && typeof element === 'object') {
               element.on('click', $tooltip.toggle);
-            } else if(trigger !== 'manual') {
+            } else if(trigger !== 'manual' && typeof element === 'object') {
               element.on(trigger === 'hover' ? 'mouseenter' : 'focus', $tooltip.enter);
               element.on(trigger === 'hover' ? 'mouseleave' : 'blur', $tooltip.leave);
               trigger !== 'hover' && element.on(isTouch ? 'touchstart' : 'mousedown', $tooltip.$onFocusElementMouseDown);


### PR DESCRIPTION
I was getting an issue on pageload when using popover, "element.on is not a function". These were occurring from some random instances of the tooltip being called where element was equal to the literal string values of 'tooltip' and 'popover'. The errors no longer occurred after checking that the 'element' was indeed an object and not any other type of variable.

This foreach loop was the only part throwing errors, I'm guessing there's something weird going on in my code that's throwing extra values in to the 'triggers' variable.
