### PR TITLE
fix($tooltip): double apply error when passed in isolated scope

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -179,6 +179,22 @@ describe('tooltip', function() {
       expect(bodyEl.children('.tooltip').length).toBe(1);
     });
 
+    it('should correctly work with ngClick in isolated scope', function() {
+      var template = templates['markup-ngClick-service'];
+      var iScope = scope.$new(true);
+      var element = $(template.element).appendTo(sandboxEl);
+      var elm = $compile(element)(iScope);
+      iScope.$digest();
+
+      var myTooltip = $tooltip(sandboxEl, angular.extend({scope:iScope,trigger: 'manual'}, templates['default'].scope.tooltip));
+      iScope.showTooltip = function() {
+        myTooltip.$promise.then(myTooltip.show);
+      };
+      expect(bodyEl.children('.tooltip').length).toBe(0);
+      angular.element(elm[0]).triggerHandler('click');
+      expect(bodyEl.children('.tooltip').length).toBe(1);
+    });
+
   });
 
   describe('options', function() {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -190,7 +190,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
 
           $animate.enter(tipElement, parent, after, function() {});
           $tooltip.$isShown = scope.$isShown = true;
-          scope.$$phase || scope.$digest();
+          scope.$$phase || scope.$root.$$phase || scope.$digest();
           $$animateReflow($tooltip.$applyPlacement);
 
           // Bind events
@@ -228,7 +228,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
             tipElement = null;
           });
           $tooltip.$isShown = scope.$isShown = false;
-          scope.$$phase || scope.$digest();
+          scope.$$phase || scope.$root.$$phase || scope.$digest();
 
           // Unbind events
           if(options.keyboard) {


### PR DESCRIPTION
I've added a test case for the isolated scope.

And there is an identical bug in $modal, should I send another PR?
