### PR TITLE
fix($modal): modal backdrop no-load add groupBy support

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -117,6 +117,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
         $modal.show = function() {
 
           scope.$emit(options.prefixClass + '.show.before', $modal);
+          bodyElement = angular.element($window.document.body);
           var parent = options.container ? findElement(options.container) : null;
           var after = options.container ? null : options.element;
 


### PR DESCRIPTION
The bug was that the backdrop element does not load in a multi-view app if the view has been routed.

The reason is that the body element loses it's reference upon view load.

the fix is to reasign that body element right at the begining of show.

Let me see if I can get a plunkr working.

Okay, I just made the plunkr.

It turned out that it is a very very corner case!!

This bug only happens, when you have your ng-view bound to the same body element as the rest of your app. Hence, when ng-view updates the content of your body element, angularStrap loses the reference.

Hi @mgcrea , I have tried to search for official opinion on using ng-view with the body in angular. Where did you see that ng-view use on the body is not supported?
