### PR TITLE
fix($scrollspy): Remove stale, cached copy on $scrollspy.destroy

### DIFF
--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -91,7 +91,9 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
           scrollEl.off('scroll', debouncedCheckPosition);
           unbindViewContentLoaded();
           unbindIncludeContentLoaded();
-
+          if (scrollId) {
+            delete spies[scrollId];
+          }
         };
 
         $scrollspy.checkPosition = function() {


### PR DESCRIPTION
In our usage scenario, we used angular-ui-router to show/hide a page
with a scrollspy. Reentering the page did not reattach scroll
listeners, because the ScrollSpyFactory returned destroyed,
dysfunctional, cached scroll spies.
