### PR TITLE
Parse modelValue using parser

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -301,7 +301,12 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
         controller.$formatters.push(function(modelValue) {
           // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
           if(angular.isUndefined(modelValue) || modelValue === null) return;
-          var date = angular.isDate(modelValue) ? modelValue : new Date(modelValue);
+          if (options.dateType === 'string') {
+            // try parse date if data type is 'string'
+            date = dateParser.parse(modelValue);
+          } else {
+            date = angular.isDate(modelValue) ? modelValue : new Date(modelValue);
+          }
           // Setup default value?
           // if(isNaN(date.getTime())) {
           //   var today = new Date();


### PR DESCRIPTION
Using date-type="string" and date-format="dd/MM/yyyy" didn't work for me, as the parsed value still used the MM/dd/yyyy format.

For example, try the following case:

<div ng-init="myDate = '14/2014/12'">
  <input type="text" class="form-control" ng-model="myDate" bs-datepicker date-type="string" date-format="dd/yyyy/MM" />
</div>
