### PR TITLE
feat(modal tooltip): Adds a feature to allow for custom name-spacing of events

### DIFF
--- a/src/modal/docs/modal.demo.html
+++ b/src/modal/docs/modal.demo.html
@@ -173,6 +173,14 @@
             <p>If provided, fetches the partial and includes it as the inner content, can be either a remote URL or a cached template id.</p>
           </td>
         </tr>
+        <tr>
+          <td>prefixEvent</td>
+          <td>string</td>
+          <td>'modal'</td>
+          <td>
+            <p>If provided, prefixes the events '.hide' '.hide.after' '.show' and '.show.after' with the passed in value. With the default value these events are 'modal.hide' 'modal.hide.after' 'modal.show' and 'modal.show.after'</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -8,6 +8,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
       animation: 'am-fade',
       backdropAnimation: 'am-fade',
       prefixClass: 'modal',
+      prefixEvent: 'modal',
       placement: 'top',
       template: 'modal/modal.tpl.html',
       contentTemplate: false,
@@ -116,7 +117,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.show = function() {
 
-          scope.$emit(options.prefixClass + '.show.before', $modal);
+          scope.$emit(options.prefixEvent + '.show.before', $modal);
           var parent = options.container ? findElement(options.container) : null;
           var after = options.container ? null : options.element;
 
@@ -138,7 +139,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
             $animate.enter(backdropElement, bodyElement, null, function() {});
           }
           $animate.enter(modalElement, parent, after, function() {
-            scope.$emit(options.prefixClass + '.show', $modal);
+            scope.$emit(options.prefixEvent + '.show', $modal);
           });
           scope.$isShown = true;
           scope.$$phase || scope.$root.$$phase || scope.$digest();
@@ -166,9 +167,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.hide = function() {
 
-          scope.$emit(options.prefixClass + '.hide.before', $modal);
+          scope.$emit(options.prefixEvent + '.hide.before', $modal);
           $animate.leave(modalElement, function() {
-            scope.$emit(options.prefixClass + '.hide', $modal);
+            scope.$emit(options.prefixEvent + '.hide', $modal);
             bodyElement.removeClass(options.prefixClass + '-open');
             if(options.animation) {
               bodyElement.addClass(options.prefixClass + '-with-' + options.animation);

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -179,8 +179,8 @@ describe('modal', function() {
       expect(emit).toHaveBeenCalledWith('modal.hide', myModal);
     });
 
-    it('should namespace show/hide events using the prefixClass', function() {
-      var myModal = $modal(angular.extend({prefixClass: 'alert'}, templates['default'].scope.modal));
+    it('should namespace show/hide events using the prefixEvent', function() {
+      var myModal = $modal(angular.extend({prefixEvent: 'alert'}, templates['default'].scope.modal));
       var emit = spyOn(myModal.$scope, '$emit');
       scope.$digest();
       myModal.hide();

--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -142,6 +142,14 @@
             <p>If provided, fetches the partial and includes it as the inner content, can be either a remote URL or a cached template id.</p>
           </td>
         </tr>
+        <tr>
+          <td>prefixEvent</td>
+          <td>string</td>
+          <td>'modal'</td>
+          <td>
+            <p>If provided, prefixes the events '.hide' '.hide.after' '.show' and '.show.after' with the passed in value. With the default value these events are 'modal.hide' 'modal.hide.after' 'modal.show' and 'modal.show.after'</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -223,8 +223,8 @@ describe('tooltip', function() {
       expect(emit).toHaveBeenCalledWith('tooltip.hide', myTooltip);
     });
 
-    it('should namespace show/hide events using the prefixClass', function() {
-      var myTooltip = $tooltip(sandboxEl, angular.extend({prefixClass: 'datepicker'}, templates['default'].scope.tooltip));
+    it('should namespace show/hide events using the prefixEvent', function() {
+      var myTooltip = $tooltip(sandboxEl, angular.extend({prefixEvent: 'datepicker'}, templates['default'].scope.tooltip));
       var emit = spyOn(myTooltip.$scope, '$emit');
       scope.$digest();
       myTooltip.show();

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -7,6 +7,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
     var defaults = this.defaults = {
       animation: 'am-fade',
       prefixClass: 'tooltip',
+      prefixEvent: 'tooltip',
       container: false,
       placement: 'top',
       template: 'tooltip/tooltip.tpl.html',
@@ -172,7 +173,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
 
         $tooltip.show = function() {
 
-          scope.$emit(options.prefixClass + '.show.before', $tooltip);
+          scope.$emit(options.prefixEvent + '.show.before', $tooltip);
           var parent = options.container ? tipContainer : null;
           var after = options.container ? null : element;
 
@@ -190,7 +191,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
           if(options.type) tipElement.addClass(options.prefixClass + '-' + options.type);
 
           $animate.enter(tipElement, parent, after, function() {
-            scope.$emit(options.prefixClass + '.show', $tooltip);
+            scope.$emit(options.prefixEvent + '.show', $tooltip);
           });
           $tooltip.$isShown = scope.$isShown = true;
           scope.$$phase || scope.$root.$$phase || scope.$digest();
@@ -226,17 +227,19 @@ angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.d
         $tooltip.hide = function(blur) {
 
           if(!$tooltip.$isShown) return;
-          scope.$emit(options.prefixClass + '.hide.before', $tooltip);
+          scope.$emit(options.prefixEvent + '.hide.before', $tooltip);
 
-          $animate.leave(tipElement, function() {
-            scope.$emit(options.prefixClass + '.hide', $tooltip);
-            tipElement = null;
-          });
+          if(tipElement !== null) {
+	        $animate.leave(tipElement, function() {
+	          scope.$emit(options.prefixEvent + '.hide', $tooltip);
+	          tipElement = null;
+	        });
+	      }
           $tooltip.$isShown = scope.$isShown = false;
           scope.$$phase || scope.$root.$$phase || scope.$digest();
 
           // Unbind events
-          if(options.keyboard) {
+          if(options.keyboard && tipElement !== null) {
             tipElement.off('keyup', $tooltip.$onKeyUp);
           }
 


### PR DESCRIPTION
This feature changes the events namespace from using options.prefixClass to options.prefixEvent. I found the need for this when I had multiple modals on the same page and wanted to do some tasks on the hide event. Using options.prefixClass also changes the classes so I couldn't continue to use the default styling, adding this option allowed me to watch for the hide event for specific modals only.

Change the use of `prefixClass` to just be used for class prefixes. Added a new option called `prefixEvent` for prefixing the events.
Allows for seperate prefix for events across multiple modals whilst not changing the classes allowing for more customisation.
Fix an error on tipElement that occurs when using the dropdown directive with a dynamically changing object as the source.

Fixes up the previous PR #636
