### PR TITLE
Ensuring element exist when executed

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -67,7 +67,7 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
 
         var hide = $dropdown.hide;
         $dropdown.hide = function() {
-          options.keyboard && $dropdown.$element.off('keydown', $dropdown.$onKeyDown);
+          options.keyboard && $dropdown.$element && $dropdown.$element.off('keydown', $dropdown.$onKeyDown);
           bodyEl.off('click', onBodyClick);
           hide();
         };


### PR DESCRIPTION
Sometimes the element does not a exist the following with be thrown: Uncaught TypeError: Cannot call method 'off' of undefined
