### PR TITLE
refactor(tooltip): drop ngAnimate dependency

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('mgcrea.ngStrap.tooltip', ['ngAnimate', 'mgcrea.ngStrap.helpers.dimensions'])
+angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
   .provider('$tooltip', function() {
 


### PR DESCRIPTION
I have found one more unneeded dependency from ngAnimate. Please remove it
ref #651
