### PR TITLE
fix(typehead): reset matches to hide tooltip

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -155,6 +155,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           hide();
         };
 
+        $typeahead.$onFocusElementMouseDown = function (evt) {};
+
         return $typeahead;
 
       }


### PR DESCRIPTION
This would close issues #632 and #652 . 

The difference between this PR and PR #658 is that this will not blur the element at all. Uses a strategy similar to ui-bootstrap's typeaheads - clears all matches on select, which has the side effect of hiding the whole typeahead until matches is repopulated.
