### PR TITLE
chore(docs): fix gulp install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Clone the repo, `git clone git://github.com/mgcrea/angular-strap.git`, [download
 AngularStrap is tested with `karma` against the latest stable release of AngularJS.
 
 >
-	$ npm install gulp-cli --global
+	$ npm install gulp --global
 	$ npm install --dev
 	$ gulp test
 


### PR DESCRIPTION
Old instructions throw an error:

```
npm ERR! 404 'gulp-cli' is not in the npm registry.
```
