### PR TITLE
fix(datepicker): fix $sce:unsafe in month/year views

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -402,6 +402,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
                 days.push({date: day, label: dateFilter(day, this.format), selected: picker.$date && this.isSelected(day), muted: day.getMonth() !== viewDate.month, disabled: this.isDisabled(day)});
               }
               scope.title = dateFilter(firstDayOfMonth, 'MMMM yyyy');
+              scope.showLabels = true;
               scope.labels = weekDaysLabelsHtml;
               scope.rows = split(days, this.split);
               this.built = true;
@@ -441,7 +442,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
                 months.push({date: month, label: dateFilter(month, this.format), selected: picker.$isSelected(month), disabled: this.isDisabled(month)});
               }
               scope.title = dateFilter(month, 'yyyy');
-              scope.labels = false;
+              scope.showLabels = false;
               scope.rows = split(months, this.split);
               this.built = true;
             },
@@ -481,7 +482,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
                 years.push({date: year, label: dateFilter(year, this.format), selected: picker.$isSelected(year), disabled: this.isDisabled(year)});
               }
               scope.title = years[0].label + '-' + years[years.length - 1].label;
-              scope.labels = false;
+              scope.showLabels = false;
               scope.rows = split(years, this.split);
               this.built = true;
             },

--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -18,7 +18,7 @@
         </button>
       </th>
     </tr>
-    <tr ng-show="labels" ng-bind-html="labels"></tr>
+    <tr ng-show="showLabels" ng-bind-html="labels"></tr>
   </thead>
   <tbody>
     <tr ng-repeat="(i, row) in rows" height="{{ 100 / rows.length }}%">


### PR DESCRIPTION
Fixes #664.

Using `scope.labels` in the `ng-show` directive is neat, but unfortunately the value `false` can't be trusted by `$sce.trustAsHtml()`.  So we use `scope.showLabels` instead.
