### PR TITLE
fix(timepicker): don't move cursor to end of input on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AngularStrap is a set of native directives that enables seamless integration of 
 - The only required dependency is [Twitter Bootstrap CSS Styles](https://github.com/twbs/bootstrap/blob/master/dist/css/bootstrap.css)!
 
 >
-AngularStrap was initially written to provide AngularJS wrapping directives for Twitter Bootstrap. It used to leverage the javascript code written by Bootstrap's contributors to minimize work, retro-compatibility issues & time to market. Editing this file to trigger a travis build.
+AngularStrap was initially written to provide AngularJS wrapping directives for Twitter Bootstrap. It used to leverage the javascript code written by Bootstrap's contributors to minimize work, retro-compatibility issues & time to market.
 >
 While it worked pretty well, it required a big javascript payload: both jQuery & Twitter Bootstrap libraries. When the 1.2 release of AngularJS showed up with the ngAnimate module, greatly simplifying DOM manipulation, we knew it was time for a rewrite!
 


### PR DESCRIPTION
Selected index remains highlighted when you change the value with arrow keys
