### PR TITLE
chore(typeahead): add support for debounce rate limit.

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStrap.helpers.parseOptions'])
+angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStrap.helpers.parseOptions', 'mgcrea.ngStrap.helpers.debounce'])
 
   .provider('$typeahead', function() {
 
@@ -16,7 +16,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
       delay: 0,
       minLength: 1,
       filter: 'filter',
-      limit: 6
+      limit: 6,
+      debounce: 300
     };
 
     this.$get = function($window, $rootScope, $tooltip) {
@@ -158,7 +159,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
   })
 
-  .directive('bsTypeahead', function($window, $parse, $q, $typeahead, $parseOptions) {
+  .directive('bsTypeahead', function($window, $parse, $q, $typeahead, $parseOptions, debounce) {
 
     var defaults = $typeahead.defaults;
 
@@ -169,7 +170,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'debounce'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
@@ -186,7 +187,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         // if(!dump) var dump = console.error.bind(console);
 
         // Watch model for changes
-        scope.$watch(attr.ngModel, function(newValue, oldValue) {
+        var debouncedWatch = debounce(function(newValue, oldValue) {
           scope.$modelValue = newValue; //Set model value on the scope to custom templates can use it.
           parsedOptions.valuesFn(scope, controller)
           .then(function(values) {
@@ -196,7 +197,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
             // Queue a new rendering that will leverage collection loading
             controller.$render();
           });
-        });
+        }, typeahead.$options.debounce);
+        scope.$watch(attr.ngModel, debouncedWatch);
 
         // Model rendering in view
         controller.$render = function () {


### PR DESCRIPTION
I'm requesting an API the suggestions for typeahead, but I didn't see any bounce or throttle rate limit controllers, so I implemented this, I suggested a default of 300 milliseconds (similar as twitter's typeahead.js).
