### PR TITLE
fix(select): re-render select to reflect change in model

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -250,6 +250,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         scope.$watch(attr.ngModel, function(newValue, oldValue) {
           // console.warn('scope.$watch(%s)', attr.ngModel, newValue, oldValue);
           select.$updateActiveIndex();
+          controller.$render();
         }, true);
 
         // Model rendering in view


### PR DESCRIPTION
the button text for the multi-select should re-render when the model changes

closes issue #660
