### PR TITLE
fix(typeahead): reset matches after render

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -72,8 +72,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         $typeahead.select = function(index) {
           var value = scope.$matches[index].value;
           controller.$setViewValue(value);
-          scope.$resetMatches();
           controller.$render();
+          scope.$resetMatches();
           if(parentScope) parentScope.$digest();
           // Emit event
           scope.$emit('$typeahead.select', value, index);


### PR DESCRIPTION
fixes issue where objects lacking a 'label' property would produce errors on select
