### PR TITLE
fix(tooltip): clear timeouts when destroying tooltips

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -155,6 +155,9 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             tipElement = null;
           }
 
+          //cancel pending callbacks
+          clearTimeout(timeout);
+
           // Destroy scope
           scope.$destroy();
 


### PR DESCRIPTION
Fix for issue #747.  I could not get tests running because of errors with templates and $httpBackend.  I noticed that you were injecting $timeout but not using it, so I wasn't sure what your plans were for timeouts and didn't know what I should mock.
