### PR TITLE
fix(dimensions): use boxRect for width an height

### DIFF
--- a/src/helpers/dimensions.js
+++ b/src/helpers/dimensions.js
@@ -44,8 +44,8 @@ angular.module('mgcrea.ngStrap.helpers.dimensions', [])
       var boxRect = element.getBoundingClientRect();
       var docElement = element.ownerDocument;
       return {
-        width: element.offsetWidth,
-        height: element.offsetHeight,
+        width: boxRect.width || element.offsetWidth,
+        height: boxRect.height || element.offsetHeight,
         top: boxRect.top + (window.pageYOffset || docElement.documentElement.scrollTop) - (docElement.documentElement.clientTop || 0),
         left: boxRect.left + (window.pageXOffset || docElement.documentElement.scrollLeft) - (docElement.documentElement.clientLeft || 0)
       };


### PR DESCRIPTION
The result `element.getBoundingClientRect()` already has width and height properties in all modern browsers (IE9+).
Moreover, some elements (in SVG, for example) don't have offsetWidth and offsetHeight and tooltips get incorrect position relative to it. After this fix `$tooltip` service can work on SVG elements, it can be so useful when creating charts.
