### PR TITLE
feat(dropdown): add 'target' attribute to links generated in dropdowns

### DIFF
--- a/src/dropdown/docs/dropdown.demo.js
+++ b/src/dropdown/docs/dropdown.demo.js
@@ -13,6 +13,7 @@ angular.module('mgcrea.ngStrapDocs')
   $scope.dropdown = [
     {text: '<i class="fa fa-download"></i>&nbsp;Another action', href: '#anotherAction'},
     {text: '<i class="fa fa-globe"></i>&nbsp;Display an alert', click: '$alert("Holy guacamole!")'},
+    {text: '<i class="fa fa-external-link"></i>&nbsp;External link', href: '/auth/facebook', target: '_self'},
     {divider: true},
     {text: 'Separated link', href: '#separatedLink'}
   ];

--- a/src/dropdown/dropdown.tpl.html
+++ b/src/dropdown/dropdown.tpl.html
@@ -1,6 +1,6 @@
 <ul tabindex="-1" class="dropdown-menu" role="menu">
   <li role="presentation" ng-class="{divider: item.divider}" ng-repeat="item in content" >
-    <a role="menuitem" tabindex="-1" ng-href="{{item.href}}" ng-if="!item.divider && item.href" ng-bind="item.text"></a>
+    <a role="menuitem" tabindex="-1" ng-href="{{item.href}}" ng-if="!item.divider && item.href" target="{{item.target || ''}}" ng-bind="item.text"></a>
     <a role="menuitem" tabindex="-1" href="javascript:void(0)" ng-if="!item.divider && item.click" ng-click="$eval(item.click);$hide()" ng-bind="item.text"></a>
   </li>
 </ul>

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -23,7 +23,7 @@ describe('dropdown', function () {
 
   var templates = {
     'default': {
-      scope: {dropdown: [{text: 'Another action', href: '#foo'}, {text: 'Something else here', click: '$alert(\'working ngClick!\')'}, {divider: true}, {text: 'Separated link', href: '#separatedLink'}]},
+      scope: {dropdown: [{text: 'Another action', href: '#foo'}, {text: 'External link', href: '/auth/facebook', target: '_self'}, {text: 'Something else here', click: '$alert(\'working ngClick!\')'}, {divider: true}, {text: 'Separated link', href: '#separatedLink'}]},
       element: '<a bs-dropdown="dropdown">click me</a>'
     },
     'markup-ngRepeat': {
@@ -85,8 +85,12 @@ describe('dropdown', function () {
       expect(sandboxEl.find('.dropdown-menu a:eq(0)').text()).toBe(scope.dropdown[0].text);
       expect(sandboxEl.find('.dropdown-menu a:eq(0)').attr('href')).toBe(scope.dropdown[0].href);
       expect(sandboxEl.find('.dropdown-menu a:eq(0)').attr('ng-click')).toBeUndefined();
-      expect(sandboxEl.find('.dropdown-menu a:eq(1)').attr('href')).toBeDefined();
-      expect(sandboxEl.find('.dropdown-menu a:eq(1)').attr('ng-click')).toBe('$eval(item.click);$hide()');
+      expect(sandboxEl.find('.dropdown-menu a:eq(1)').text()).toBe(scope.dropdown[1].text);
+      expect(sandboxEl.find('.dropdown-menu a:eq(1)').attr('href')).toBe(scope.dropdown[1].href);
+      expect(sandboxEl.find('.dropdown-menu a:eq(1)').attr('target')).toBe(scope.dropdown[1].target);
+      expect(sandboxEl.find('.dropdown-menu a:eq(1)').attr('ng-click')).toBeUndefined();
+      expect(sandboxEl.find('.dropdown-menu a:eq(2)').attr('href')).toBeDefined();
+      expect(sandboxEl.find('.dropdown-menu a:eq(2)').attr('ng-click')).toBe('$eval(item.click);$hide()');
     });
 
     it('should support ngRepeat markup', function() {
@@ -176,11 +180,11 @@ describe('dropdown', function () {
         $templateCache.put('custom', '<div class="dropdown"><div class="dropdown-inner"><ul><li ng-repeat="item in dropdown">{{$index}}</li></ul></div></div>');
         var elm = compileDirective('options-template');
         angular.element(elm[0]).triggerHandler('click');
-        expect(sandboxEl.find('.dropdown-inner').text()).toBe('0123');
+        expect(sandboxEl.find('.dropdown-inner').text()).toBe('01234');
         // Consecutive toggles
         angular.element(elm[0]).triggerHandler('click');
         angular.element(elm[0]).triggerHandler('click');
-        expect(sandboxEl.find('.dropdown-inner').text()).toBe('0123');
+        expect(sandboxEl.find('.dropdown-inner').text()).toBe('01234');
       });
 
       it('should support template with ngClick', function() {


### PR DESCRIPTION
There are cases when one needs to explicitly specify anchor `target` attribute, for example to bypass angular router and make actual server request like described [here](http://stackoverflow.com/questions/11580004/angular-js-link-behaviour-disable-deep-linking-for-specific-urls)
This PR adds the possibility to specify `target` property in dropdown datasource.

P.S. I've added test but unfortunately can not run it due to huge amount of errors on `npm install`.
