### PR TITLE
feat(datepicker, timepicker, select): CSS icons customization

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -25,7 +25,9 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
       maxDate: +Infinity,
       startView: 0,
       minView: 0,
-      startWeek: 0
+      startWeek: 0,
+      iconLeft: 'glyphicon glyphicon-chevron-left',
+      iconRight: 'glyphicon glyphicon-chevron-right'
     };
 
     this.$get = function($window, $document, $rootScope, $sce, $locale, dateFilter, datepickerViews, $tooltip) {
@@ -49,6 +51,8 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
         $datepicker.$views = pickerViews.views;
         var viewDate = pickerViews.viewDate;
         scope.$mode = options.startView;
+        scope.$iconLeft = options.iconLeft;
+        scope.$iconRight = options.iconRight;
         var $picker = $datepicker.$views[scope.$mode];
 
         // Scope methods

--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -4,7 +4,7 @@
     <tr class="text-center">
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$selectPane(-1)">
-          <i class="glyphicon glyphicon-chevron-left"></i>
+          <i class="{{$iconLeft}}"></i>
         </button>
       </th>
       <th colspan="{{ rows[0].length - 2 }}">
@@ -14,7 +14,7 @@
       </th>
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-right" ng-click="$selectPane(+1)">
-          <i class="glyphicon glyphicon-chevron-right"></i>
+          <i class="{{$iconRight}}"></i>
         </button>
       </th>
     </tr>

--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -210,6 +210,22 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
             <p>First day of the week.</p>
           </td>
         </tr>
+        <tr>
+          <td>iconLeft</td>
+          <td>string</td>
+          <td>'glyphicon glyphicon-chevron-left'</td>
+          <td>
+            <p>CSS class for 'left' icon.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>iconRight</td>
+          <td>string</td>
+          <td>'glyphicon glyphicon-chevron-right'</td>
+          <td>
+            <p>CSS class for 'right' icon.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/select/docs/select.demo.html
+++ b/src/select/docs/select.demo.html
@@ -159,6 +159,14 @@ $scope.icons = "{{icons}}";
             <p>Placeholder text when no value is selected.</p>
           </td>
         </tr>
+        <tr>
+          <td>iconCheckmark</td>
+          <td>string</td>
+          <td>'glyphicon glyphicon-ok'</td>
+          <td>
+            <p>CSS class for 'checkmark' icon.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -19,7 +19,8 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
       caretHtml: '&nbsp;<span class="caret"></span>',
       placeholder: 'Choose among the following...',
       maxLength: 3,
-      maxLengthHtml: 'selected'
+      maxLengthHtml: 'selected',
+      iconCheckmark: 'glyphicon glyphicon-ok'
     };
 
     this.$get = function($window, $document, $rootScope, $tooltip) {
@@ -41,6 +42,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         scope.$matches = [];
         scope.$activeIndex = 0;
         scope.$isMultiple = options.multiple;
+        scope.$iconCheckmark = options.iconCheckmark;
 
         scope.$activate = function(index) {
           scope.$$postDigest(function() {

--- a/src/select/select.tpl.html
+++ b/src/select/select.tpl.html
@@ -2,7 +2,7 @@
   <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive($index)}">
     <a style="cursor: default;" role="menuitem" tabindex="-1" ng-click="$select($index, $event)">
       <span ng-bind="match.label"></span>
-      <i class="glyphicon glyphicon-ok pull-right" ng-if="$isMultiple && $isActive($index)"></i>
+      <i class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive($index)"></i>
     </a>
   </li>
 </ul>

--- a/src/timepicker/docs/timepicker.demo.html
+++ b/src/timepicker/docs/timepicker.demo.html
@@ -212,6 +212,22 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
             <p>Default step for minutes.</p>
           </td>
         </tr>
+        <tr>
+          <td>iconUp</td>
+          <td>string</td>
+          <td>'glyphicon glyphicon-chevron-up'</td>
+          <td>
+            <p>CSS class for 'up' icon.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>iconDown</td>
+          <td>string</td>
+          <td>'glyphicon glyphicon-chevron-down'</td>
+          <td>
+            <p>CSS class for 'down' icon.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -23,7 +23,9 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
       maxTime: +Infinity,
       length: 5,
       hourStep: 1,
-      minuteStep: 5
+      minuteStep: 5,
+      iconUp: 'glyphicon glyphicon-chevron-up',
+      iconDown: 'glyphicon glyphicon-chevron-down'
     };
 
     this.$get = function($window, $document, $rootScope, $sce, $locale, dateFilter, $tooltip) {
@@ -41,12 +43,16 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         var scope = $timepicker.$scope;
 
         // View vars
+
         var selectedIndex = 0;
         var startDate = controller.$dateValue || new Date();
         var viewDate = {hour: startDate.getHours(), meridian: startDate.getHours() < 12, minute: startDate.getMinutes(), second: startDate.getSeconds(), millisecond: startDate.getMilliseconds()};
 
         var format = $locale.DATETIME_FORMATS[options.timeFormat] || options.timeFormat;
         var formats = /(h+)[:]?(m+)[ ]?(a?)/i.exec(format).slice(1);
+        scope.$iconUp = options.iconUp;
+        scope.$iconDown = options.iconDown;
+
         // Scope methods
 
         scope.$select = function(date, index) {

--- a/src/timepicker/timepicker.tpl.html
+++ b/src/timepicker/timepicker.tpl.html
@@ -4,7 +4,7 @@
     <tr class="text-center">
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$moveIndex(-1, 0)">
-          <i class="glyphicon glyphicon-chevron-up"></i>
+          <i class="{{$iconUp}}"></i>
         </button>
       </th>
       <th>
@@ -12,7 +12,7 @@
       </th>
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$moveIndex(-1, 1)">
-          <i class="glyphicon glyphicon-chevron-up"></i>
+          <i class="{{$iconUp}}"></i>
         </button>
       </th>
     </tr>
@@ -45,7 +45,7 @@
     <tr class="text-center">
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$moveIndex(1, 0)">
-          <i class="glyphicon glyphicon-chevron-down"></i>
+          <i class="{{$iconDown}}"></i>
         </button>
       </th>
       <th>
@@ -53,7 +53,7 @@
       </th>
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$moveIndex(1, 1)">
-          <i class="glyphicon glyphicon-chevron-down"></i>
+          <i class="{{$iconDown}}"></i>
         </button>
       </th>
     </tr>


### PR DESCRIPTION
Add possibility to customize CSS classes for top/bottom/left/right arrow icons used in datepicker and timepicker and checkmark icon used in select. Useful for cases with non-standard Bootstrap icon fonts like [Fontello](http://fontello.com).
