### PR TITLE
Fix bug when scope is destroyed before tooltip hide() is complete

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -149,11 +149,14 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             }
           }
 
-          // Remove element
-          if(tipElement) {
-            tipElement.remove();
-            tipElement = null;
-          }
+
+          scope.$$postDigest(function() {
+              // Remove element
+              if(tipElement) {
+                tipElement.remove();
+                tipElement = null;
+              }
+          });
 
           //cancel pending callbacks
           clearTimeout(timeout);


### PR DESCRIPTION
Hello,

This pull request resolves a bug I encountered when attempting to navigate from a bs-dropdown to a different page.  The navigation resulted in the scope being destroyed before $tooltip.hide() was called.  In this situation stepping through the code clearly shows that $tooltip.destroy is called before $tooltip.hide, resulting in an exception  Please fine below the stack trace.

The solution I implemented was to simply put the $tooltip.remove() in a postDigest() so that the order is swapped.  I can imagine other solutions that would work equally well  (e.g. make hide() handle the case where the element has been removed from the DOM, or cancel the postDigest hide when destroy is called).

Thanks,
Rob

TypeError: Cannot read property 'length' of null
    at extractElementNode (http://localhost:3000/i3/bower_components/angular-animate/angular-animate.js:288:33)
    at cancelChildAnimations (http://localhost:3000/i3/bower_components/angular-animate/angular-animate.js:876:20)
    at Object.leave (http://localhost:3000/i3/bower_components/angular-animate/angular-animate.js:442:11)
    at TooltipFactory.$tooltip.hide (http://localhost:3000/i3/bower_components/angular-strap/dist/angular-strap.js:3534:20)
    at Object.DropdownFactory.$dropdown.hide (http://localhost:3000/i3/bower_components/angular-strap/dist/angular-strap.js:1204:11)
    at http://localhost:3000/i3/bower_components/angular-strap/dist/angular-strap.js:3366:22
    at Scope.$digest (http://localhost:3000/i3/bower_components/angular/angular.js:11881:36)
    at Scope.$apply (http://localhost:3000/i3/bower_components/angular/angular.js:12083:24)
    at HTMLAnchorElement.<anonymous> (http://localhost:3000/i3/bower_components/angular/angular.js:18002:21)
    at HTMLAnchorElement.jQuery.event.dispatch (http://localhost:3000/i3/bower_components/jquery/dist/jquery.js:4409:9)
