### PR TITLE
chore(dimensions): docstring typo

### DIFF
--- a/src/helpers/dimensions.js
+++ b/src/helpers/dimensions.js
@@ -129,7 +129,7 @@ angular.module('mgcrea.ngStrap.helpers.dimensions', [])
     };
 
     /**
-     * Provides equivalent of jQuery's height function
+     * Provides equivalent of jQuery's width function
      * @required-by bootstrap-affix
      * @url http://api.jquery.com/width/
      * @param element


### PR DESCRIPTION
width is equivalent of jQuery's width not height
