### PR TITLE
Add .open class to drop down parent (<li>) when it is open. This is nece...

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -63,12 +63,14 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
             options.keyboard && $dropdown.$element.on('keydown', $dropdown.$onKeyDown);
             bodyEl.on('click', onBodyClick);
           });
+          $dropdown.$element.parent().toggleClass('open');
         };
 
         var hide = $dropdown.hide;
         $dropdown.hide = function() {
           options.keyboard && $dropdown.$element.off('keydown', $dropdown.$onKeyDown);
           bodyEl.off('click', onBodyClick);
+          $dropdown.$element.parent().toggleClass('open');
           hide();
         };
 

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -26,6 +26,9 @@ describe('dropdown', function () {
       scope: {dropdown: [{text: 'Another action', href: '#foo'}, {text: 'External link', href: '/auth/facebook', target: '_self'}, {text: 'Something else here', click: '$alert(\'working ngClick!\')'}, {divider: true}, {text: 'Separated link', href: '#separatedLink'}]},
       element: '<a bs-dropdown="dropdown">click me</a>'
     },
+    'in-navbar': {
+      element: '<div class="collapse navbar-collapse"><ul class="nav navbar-nav"><li class="dropdown"><a bs-dropdown="dropdown">click me</a></li></ul>'
+    },
     'markup-ngRepeat': {
       element: '<ul><li ng-repeat="i in [1, 2, 3]"><a bs-dropdown="dropdown">{{i}}</a></li></ul>'
     },
@@ -100,6 +103,16 @@ describe('dropdown', function () {
       expect(sandboxEl.find('.dropdown-menu a:eq(0)').text()).toBe(scope.dropdown[0].text);
     });
 
+  });
+
+  describe('in navbar', function() {
+    it('should add class .open to the parent <li> when dropdown is open', function() {
+      var elm = compileDirective('in-navbar');
+      angular.element(elm.find('a')).triggerHandler('click');
+      expect(sandboxEl.find('.dropdown').hasClass('open')).toBeTruthy();
+      angular.element(elm.find('a')).triggerHandler('click');
+      expect(sandboxEl.find('.dropdown').hasClass('open')).toBeFalsy();
+    });
   });
 
 


### PR DESCRIPTION
...ssary so the dropdown works properly in a responsive Bootstrap navbar. Without the .open class, the dropdown menu is not rendered properly if the navbar is collapsed.
![screen shot of collapsed navbar showing issue](https://cloud.githubusercontent.com/assets/283872/3137467/e66361f6-e853-11e3-9835-c7de0941135e.png)

![screen shot of collapsed navbar w/fix](https://cloud.githubusercontent.com/assets/283872/3137472/f34ba1ee-e853-11e3-96a3-bff613b1aa53.png)

I'm not sure if this fix is the best approach. In a Bootstrap navbar, the <li> that contains the bs-dropdown element needs the ".open" class applied to it. I felt dirty doing $element.parent().
