### PR TITLE
Toggle fix when radio input element inside label.

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -150,7 +150,7 @@ angular.module('mgcrea.ngStrap.button', [])
         };
 
         // view -> model
-        element.bind(options.toggleEvent, function() {
+        activeElement.bind(options.toggleEvent, function() {
           scope.$apply(function () {
             // console.warn('!click', element.attr('value'), 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue, 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue);
             controller.$setViewValue(value);


### PR DESCRIPTION
At least it does not work for me without this fix, when the input[type=radio] is nested in a label element. Seeing as it works on the docs pages, I might have made another mistake somewhere else. However, it seems to me that it makes sense that the click event should be bound on the label in that case, and not on the invisible input[type=radio]. At least in my case, the click event never fires on the nested & hidden input.

If valid, the same fix should probably be applied for input[type=checkbox]. I do not have a test case immediately available for that, so I won't presume to "correct" it.
