### PR TITLE
feat($tooltip, $modal): change options.container to allow an angular.element

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -118,7 +118,12 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
         $modal.show = function() {
 
           scope.$emit(options.prefixEvent + '.show.before', $modal);
-          var parent = options.container ? findElement(options.container) : null;
+          var parent;
+          if(angular.isElement(options.container)) {
+            parent = options.container;
+          } else {
+            parent = options.container ? findElement(options.container) : null;
+          }
           var after = options.container ? null : options.element;
 
           // Fetch a cloned element linked from template

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -274,6 +274,16 @@ describe('modal', function() {
 
     });
 
+    describe('container', function() {
+      it('accepts element object', function() {
+      	var testElm = angular.element('<div></div>');
+      	sandboxEl.append(testElm);
+        var myModal = $modal(angular.extend({}, templates['default'].scope.modal, {container: testElm}));
+        scope.$digest();
+        expect(angular.element(testElm.children()[0]).hasClass('modal')).toBeTruthy();
+      });
+    });
+
   });
 
 });

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -367,6 +367,18 @@ describe('tooltip', function() {
 
     });
 
+    describe('container', function() {
+      it('accepts element object', function() {
+      	var testElm = angular.element('<div></div>');
+      	sandboxEl.append(testElm);
+        var myTooltip = $tooltip(sandboxEl, angular.extend({}, templates['default'].scope.tooltip, {container: testElm}));
+        scope.$digest();
+        myTooltip.show();
+        $animate.triggerCallbacks();
+        expect(angular.element(testElm.children()[0]).hasClass('tooltip')).toBeTruthy();
+      });
+    });
+
   });
 
 });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -110,6 +110,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           // Options : container
           if(options.container === 'self') {
             tipContainer = element;
+          } else if(angular.isElement(options.container)) {
+            tipContainer = options.container;
           } else if(options.container) {
             tipContainer = findElement(options.container);
           }


### PR DESCRIPTION
This allows the container option of tooltips, modals and other directives that use them to use an angular.element object not just a selector string. Mainly for use when being used inside custom directives and you can't easily use selectors but already have a element object.
