### PR TITLE
fix: scope is null on destroy when popover is triggered by hover with de...

### DIFF
--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -85,9 +85,11 @@ angular.module('mgcrea.ngStrap.popover', ['mgcrea.ngStrap.tooltip'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          popover.destroy();
-          options = null;
-          popover = null;
+		if (popover !== null) {
+			  popover.destroy();
+			  options = null;
+			  popover = null;
+		  }
         });
 
       }

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -206,7 +206,9 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             scope.$emit(options.prefixEvent + '.show', $tooltip);
           });
           $tooltip.$isShown = scope.$isShown = true;
-          scope.$$phase || (scope.$root && scope.$root.$$phase) || scope.$digest();
+		  if (scope !== null) {
+			scope.$$phase || (scope.$root && scope.$root.$$phase) || scope.$digest();
+		  }
           $$rAF($tooltip.$applyPlacement); // var a = bodyEl.offsetWidth + 1; ?
 
           // Bind events


### PR DESCRIPTION
...lay and navigating between pages. 10612phase called when scope is null
In the popover - scope.$on('$destory',..) the error message is:
"Cannot read property 'destroy' of null" at line 2320 in angular-strap.js
