### PR TITLE
Allow to set an expression as title attribute

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -414,7 +414,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Observe scope attributes for change
         angular.forEach(['title'], function(key) {
-          attr[key] && attr.$observe(key, function(newValue, oldValue) {
+          attr.$observe(key, function(newValue, oldValue) {
             scope[key] = $sce.trustAsHtml(newValue);
             angular.isDefined(oldValue) && $$rAF(function() {
               tooltip && tooltip.$applyPlacement();


### PR DESCRIPTION
Without this fix, I can't pass a variable as the title attribute. I can only set a constant string. I want to set an expression to localize my title like :

```
<div data-title="{{'mytext'|i18n}}" bs-tootltip></div>
```
