### PR TITLE
fix(modal) remove animation class from body element on hide

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -172,7 +172,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
             scope.$emit(options.prefixEvent + '.hide', $modal);
             bodyElement.removeClass(options.prefixClass + '-open');
             if(options.animation) {
-              bodyElement.addClass(options.prefixClass + '-with-' + options.animation);
+              bodyElement.removeClass(options.prefixClass + '-with-' + options.animation);
             }
           });
           if(options.backdrop) {


### PR DESCRIPTION
I was stacking modals on top of each other and noticed that the animation class never gets removed from the body element when the modal his hidden.
