### PR TITLE
De-activate all options if empty model

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -266,6 +266,9 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
             } else {
               selected = selected.join(', ');
             }
+            if (controller.$modelValue.length === 0) {
+              select.$scope.$activeIndex = [];
+            }
           } else {
             index = select.$getIndex(controller.$modelValue);
             selected = angular.isDefined(index) ? select.$scope.$matches[index].label : false;


### PR DESCRIPTION
I'm sure there is a better way to do this but basically when updating the model of a bsSelect from a controller, only the placeholder is updated not the drop-down list.
