### PR TITLE
Fix bug in typeahead when selecting a no string value like an Object or ...

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -203,7 +203,9 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           var index = typeahead.$getIndex(controller.$modelValue);
           var selected = angular.isDefined(index) ? typeahead.$scope.$matches[index].label : controller.$viewValue;
           selected = angular.isObject(selected) ? selected.label : selected;
-          element.val(selected.replace(/<(?:.|\n)*?>/gm, '').trim());
+          if (selected && selected.replace) {
+            element.val(selected.replace(/<(?:.|\n)*?>/gm, '').trim());
+          }
         };
 
         // Garbage collection


### PR DESCRIPTION
...a Number
