### PR TITLE
fix(datepicker): adds missing iconLeft/iconRight as attributes on directive

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -252,7 +252,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'useNative', 'lang', 'startView', 'minView'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
iconLeft and iconRight on datepicker not being picked up by the directive

<input type="text" ng-model="selectedDate" bs-datepicker
      icon-left="fa fa-hand-o-left" icon-right="fa fa-hand-o-right" >

see http://plnkr.co/edit/z5KvqIrd06gvlX89994P?p=preview
