### PR TITLE
Added a Custom-Class option to Tooltips.

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -6,6 +6,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
     var defaults = this.defaults = {
       animation: 'am-fade',
+      customClass: '',
       prefixClass: 'tooltip',
       prefixEvent: 'tooltip',
       container: false,
@@ -201,6 +202,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           if(options.animation) tipElement.addClass(options.animation);
           // Options: type
           if(options.type) tipElement.addClass(options.prefixClass + '-' + options.type);
+          // Options: custom classes
+          if(options.customClass) tipElement.addClass(options.customClass);
 
           $animate.enter(tipElement, parent, after, function() {
             scope.$emit(options.prefixEvent + '.show', $tooltip);
@@ -408,7 +411,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'target', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'type'], function(key) {
+        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'target', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'type', 'customClass'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
We had a need for custom classes per tootip (i.e. delete tootips to have a red background etc.) - so we've added a quick-fix with a CustomClass option.

i.e. `<div bs-tooltip title="Some great message" custom-class="awesome-custom class-here">Hover Me</div>`

Apologies if there is already an out-of-the-box way to do this with ng-strap (it seemed like a natural thing to want for customisation?). 

Otherwise: I hope its useful!

Kudos for creating the project,

D.
