### PR TITLE
fix(tooltip) fix options.target not being passed as DOMElement to dimensions.position

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "test": "gulp test"
+    "test": "gulp jshint karma:unit"
   }
 }

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -309,9 +309,9 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         function getPosition() {
           if(options.container === 'body') {
-            return dimensions.offset(options.target || element[0]);
+            return dimensions.offset(options.target[0] || element[0]);
           } else {
-            return dimensions.position(options.target || element[0]);
+            return dimensions.position(options.target[0] || element[0]);
           }
         }
 


### PR DESCRIPTION
The error occurs as options.target is validated via `angular.isElement` [tooltip.js#L131](https://github.com/SimeonC/angular-strap/blob/e738c9dc4f3e562801aaf82c878b78a6da0ac0c8/src/tooltip/tooltip.js#L131) which requires a valid jQlite/jquery wrapped DOMElement, this gives an error in getPosition() as dimensions.position requires an unwrapped DOMElement.

(Also fixed package.json so that `npm test` runs the same as travis-ci. Otherwise it just seems to permanently pass.)
