### PR TITLE
Removed JQuery dependency from Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,18 +33,18 @@
     "CONTRIBUTING.md"
   ],
   "dependencies": {
-    "angular": "~1.2.18",
+    "angular": "~1.2.16",
     "bootstrap": "~3.1.1",
     "angular-motion": "~0.3.3"
   },
   "devDependencies": {
-    "angular-animate": "~1.2.18",
-    "angular-i18n": "~1.2.18",
-    "angular-mocks": "~1.2.18",
+    "angular-animate": "~1.2.16",
+    "angular-i18n": "~1.2.16",
+    "angular-mocks": "~1.2.16",
     "angular-motion": "~0.3.1",
-    "angular-route": "~1.2.18",
-    "angular-sanitize": "~1.2.18",
-    "angular-scenario": "~1.2.18",
+    "angular-route": "~1.2.16",
+    "angular-sanitize": "~1.2.16",
+    "angular-scenario": "~1.2.16",
     "fastclick": "~1.0.2",
     "font-awesome": "~4.1.0",
     "highlightjs": "~8.0.0"


### PR DESCRIPTION
AFAIK the JQuery requirement was removed in v2; and doing a quick `grep` shows that JQuery is still used in tests, but nowhere else.
