### PR TITLE
Fix to "Cannot read property 'destroy' of null" error on removing element containing datepicker

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -376,7 +376,9 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          datepicker.destroy();
+          if (datepicker) {
+            datepicker.destroy();
+          }
           options = null;
           datepicker = null;
         });


### PR DESCRIPTION
Fixed issue with error 'Cannot read property 'destroy' of null' being thrown in the console if a date picker was inside an accordion or popover that closed
