### PR TITLE
feat(datepicker): add the ability to disable specific days of the week t...

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -27,6 +27,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
       startView: 0,
       minView: 0,
       startWeek: 0,
+      daysOfWeekDisabled: '',
       iconLeft: 'glyphicon glyphicon-chevron-left',
       iconRight: 'glyphicon glyphicon-chevron-right'
     };
@@ -252,7 +253,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
@@ -461,6 +462,9 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
               // Disabled because of min/max date.
               if (time < options.minDate || time > options.maxDate) return true;
+
+              // Disabled due to being a disabled day of the week
+              if (options.daysOfWeekDisabled.indexOf(date.getDay()) !== -1) return true;
 
               // Disabled because of disabled date range.
               if (options.disabledDateRanges) {

--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -226,6 +226,14 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
             <p>CSS class for 'right' icon.</p>
           </td>
         </tr>
+        <tr>
+          <td>daysOfWeekDisabled</td>
+          <td>string</td>
+          <td>''</td>
+          <td>
+            <p>List of decimal days of the week values that are disabled and hence cannot be selected. For example, '06' disables Sunday and Saturday, '12345' disables Monday to Friday.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -122,7 +122,15 @@ describe('datepicker', function() {
     'options-modelDateFormat': {
       scope: {selectedDate: '2014-12-01' },
       element: '<input type="text" ng-model="selectedDate" data-date-format="dd/MM/yyyy" data-model-date-format="yyyy-MM-dd" data-date-type="string" bs-datepicker>'
-    }
+    },
+    'options-daysOfWeekDisabled': {
+      scope: {selectedDate: new Date(2014, 6, 27)},
+      element: '<input type="text" ng-model="selectedDate" data-days-of-week-disabled="{{daysOfWeekDisabled}}" bs-datepicker>'
+    },
+    'options-daysOfWeekDisabled-bis': {
+      scope: {selectedDate: new Date(2014, 6, 27), daysOfWeekDisabled: "0246"},
+      element: '<input type="text" ng-model="selectedDate" data-days-of-week-disabled="{{daysOfWeekDisabled}}" bs-datepicker>'
+    },
   };
 
   function compileDirective(template, locals) {
@@ -614,5 +622,33 @@ describe('datepicker', function() {
     });
 
   });
+
+  describe('daysOfWeekDisabled', function() {
+
+      it('should enable all days of the week by default', function() {
+        var elm = compileDirective('options-daysOfWeekDisabled');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(20)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(21)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(22)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(23)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(24)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(25)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(26)').is(':disabled')).toBeFalsy();
+      });
+
+      it('should allow disabling some days of the week', function() {
+        var elm = compileDirective('options-daysOfWeekDisabled-bis');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(20)').is(':disabled')).toBeTruthy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(21)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(22)').is(':disabled')).toBeTruthy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(23)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(24)').is(':disabled')).toBeTruthy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(25)').is(':disabled')).toBeFalsy();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(26)').is(':disabled')).toBeTruthy();
+      });
+
+    });
 
 });


### PR DESCRIPTION
...o the datepicker

Change the date picker to add the ability to choose to disable specific days of the week.
Adds an option, daysOfWeekDisabled, that is a string with the default value of '' (empty string).
To disable days of the week, append the appropriate value for the day of the week that is
desired to be disabled, with 0=Sun, 1=Mon, etc. For example, to disable Sat and Sun, add the
attribute days-of-week-disabled="06" to the element when using the datepicker directive.
