### PR TITLE
Submit form with <Enter>key on typeahead field

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -108,10 +108,10 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         $typeahead.$onKeyDown = function(evt) {
           if(!/(38|40|13)/.test(evt.keyCode)) return;
-          evt.preventDefault();
 
           // Let ngSubmit pass if the typeahead tip is hidden
           if($typeahead.$isVisible()) {
+            evt.preventDefault();
             evt.stopPropagation();
           }
 


### PR DESCRIPTION
The form submission is now prevented by 
  evt.preventDefault()
which surpesses the default behavior (in this case submit the form).

A fix for this bug was implemented (see comment in code) but does not work, since only propagation is not stopped, but default behavior is prevented.
