### PR TITLE
fix(tooltip): move element blur action to animation.leave() callback

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -254,6 +254,11 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
           $animate.leave(tipElement, function() {
             scope.$emit(options.prefixEvent + '.hide', $tooltip);
+
+            // Allow to blur the input when hidden, like when pressing enter key
+            if(blur && options.trigger === 'focus') {
+              return element[0].blur();
+            }
           });
 
           $tooltip.$isShown = scope.$isShown = false;
@@ -262,11 +267,6 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           // Unbind events
           if(options.keyboard && tipElement !== null) {
             tipElement.off('keyup', $tooltip.$onKeyUp);
-          }
-
-          // Allow to blur the input when hidden, like when pressing enter key
-          if(blur && options.trigger === 'focus') {
-            return element[0].blur();
           }
 
         };


### PR DESCRIPTION
An $apply already in progress exception is thrown when there are other
directives that bind to the element 'blur' event, by executing the blur
event inside the animation callback the DOM event is triggered outside
the angular $digest cycle.

References #750
