### PR TITLE
fix(alert, aside, dropdown, modal, popover, scrollspy, select, timepicker, typeahead): fail-safe destroy

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -101,7 +101,7 @@ angular.module('mgcrea.ngStrap.alert', ['mgcrea.ngStrap.modal'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          alert.destroy();
+          if (alert) alert.destroy();
           options = null;
           alert = null;
         });

--- a/src/aside/aside.js
+++ b/src/aside/aside.js
@@ -77,7 +77,7 @@ angular.module('mgcrea.ngStrap.aside', ['mgcrea.ngStrap.modal'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          aside.destroy();
+          if (aside) aside.destroy();
           options = null;
           aside = null;
         });

--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -115,7 +115,7 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          dropdown.destroy();
+          if (dropdown) dropdown.destroy();
           options = null;
           dropdown = null;
         });

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -285,7 +285,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          modal.destroy();
+          if (modal) modal.destroy();
           options = null;
           modal = null;
         });

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -93,7 +93,7 @@ angular.module('mgcrea.ngStrap.popover', ['mgcrea.ngStrap.tooltip'])
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          popover.destroy();
+          if (popover) popover.destroy();
           options = null;
           popover = null;
         });

--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -221,8 +221,10 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
         scrollspy.trackElement(options.target, element);
 
         scope.$on('$destroy', function() {
-          scrollspy.untrackElement(options.target, element);
-          scrollspy.destroy();
+          if (scrollspy) {
+            scrollspy.untrackElement(options.target, element);
+            scrollspy.destroy();
+          }
           options = null;
           scrollspy = null;
         });

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -295,7 +295,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          select.destroy();
+          if (select) select.destroy();
           options = null;
           select = null;
         });

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -419,7 +419,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          timepicker.destroy();
+          if (timepicker) timepicker.destroy();
           options = null;
           timepicker = null;
         });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -234,7 +234,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Garbage collection
         scope.$on('$destroy', function() {
-          typeahead.destroy();
+          if (typeahead) typeahead.destroy();
           options = null;
           typeahead = null;
         });


### PR DESCRIPTION
To match @f8fe919fbf755309339936ef1cd256ed05e39f00 and @21b049f61c73bda16a0b4afccf8a1c135cfdbf23
