### PR TITLE
Add explicit index to $matches

### DIFF
--- a/src/helpers/parse-options.js
+++ b/src/helpers/parse-options.js
@@ -47,7 +47,7 @@ angular.module('mgcrea.ngStrap.helpers.parseOptions', [])
             locals[valueName] = match;
             label = displayFn(scope, locals);
             value = valueFn(scope, locals) || index;
-            return {label: label, value: value};
+            return {label: label, value: value, index: index};
           });
         }
 

--- a/src/select/select.tpl.html
+++ b/src/select/select.tpl.html
@@ -5,10 +5,10 @@
       <button class="btn btn-default btn-xs" ng-click="$selectNone()">None</button>
     </div>
   </li>
-  <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive($index)}">
-    <a style="cursor: default;" role="menuitem" tabindex="-1" ng-click="$select($index, $event)">
+  <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive(match.index)}">
+    <a style="cursor: default;" role="menuitem" tabindex="-1" ng-click="$select(match.index, $event)">
       <span ng-bind="match.label"></span>
-      <i class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive($index)"></i>
+      <i class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive(match.index)"></i>
     </a>
   </li>
 </ul>


### PR DESCRIPTION
Hi,

I've been implementing a custom select drop-down template to provide a search feature for long lists. The existing method in the `bs-select` for retrieving the item doesn't work because the `$index` within the filtered scope changes in relation to the indexes of the `$matches` (I think that's how to describe it).

Anyway, here is my PR to add an explicit index and makes the following code possible:

``` html
<input type="text" class="form-control" ng-model="selectFilter" placeholder="Filter..."/>
<li role="presentation" ng-repeat="match in $matches | filter:selectFilter" ng-class="{active: $isActive(match.index)}">
```

PS. this change works with my project but I have no idea how to provide create a unit test to prove this.
