### PR TITLE
Stop event propagation when ESC is pressed

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -210,7 +210,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.$onKeyUp = function(evt) {
 
-          if (evt.which === 27) {
+          if (evt.which === 27 && scope.$isShown) {
             $modal.hide();
             evt.stopPropagation();
           }

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -219,6 +219,16 @@ describe('modal', function() {
         expect(evt.stopPropagation).toHaveBeenCalled();
       });
 
+      it('should NOT stopPropagation if ESC is pressed while modal is hidden', function() {
+        var myModal = $modal(templates['default'].scope.modal);
+        scope.$digest();
+        myModal.hide();
+        var evt = jQuery.Event( 'keyup', { keyCode: 27, which: 27 } );
+        spyOn(evt, 'stopPropagation');
+        myModal.$onKeyUp(evt);
+        expect(evt.stopPropagation).not.toHaveBeenCalled();
+      });
+
     });
 
     describe('placement', function() {

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -304,6 +304,15 @@ describe('tooltip', function() {
         expect(evt.stopPropagation).toHaveBeenCalled();
       });
 
+      it('should NOT stopPropagation if ESC is pressed while tooltip is hidden', function() {
+        var myTooltip = $tooltip(sandboxEl, angular.extend({trigger: 'click'}, templates['options-keyboard'].scope.tooltip));
+        scope.$digest();
+        var evt = jQuery.Event( 'keyup', { keyCode: 27, which: 27 } );
+        spyOn(evt, 'stopPropagation');
+        myTooltip.$onKeyUp(evt);
+        expect(evt.stopPropagation).not.toHaveBeenCalled();
+      });
+
       it('should blur and stopPropagation if ESC is pressed when trigger === "focus"', function() {
         var myTooltip = $tooltip(sandboxEl, angular.extend({trigger: 'focus'}, templates['options-keyboard'].scope.tooltip));
         spyOn(sandboxEl[0], 'blur');

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -302,7 +302,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
         };
 
         $tooltip.$onKeyUp = function(evt) {
-          if (evt.which === 27) {
+          if (evt.which === 27 && $tooltip.$isShown) {
             $tooltip.hide();
             evt.stopPropagation();
           }


### PR DESCRIPTION
Without this change to tooltip, using a component such as typeAhead inside a modal causes expected behavior when the ESC key is pressed.
- Expected behavior: typeahead dismisses and modal remains open.
- Actual behavior: typeahead and modal both dismiss (both handle the ESC key).

The corresponding change to modal was made for behavioral consistency to avoid potential similar issues.
