### PR TITLE
Affix: getScrollTop was returning boolean for bs-affix-target elements instead of scrollTop

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -176,7 +176,7 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
         }
 
         function getScrollTop() {
-          return targetEl[0] === $window ? $window.pageYOffset : targetEl[0] === $window;
+          return targetEl[0] === $window ? $window.pageYOffset : targetEl[0].scrollTop;
         }
 
         function getScrollHeight() {


### PR DESCRIPTION
Fixes issue #992
### Summary of issue

`getScrollTop` returns a boolean when it should return scrollTop when `bs-affix-target` is used
### Code

The offending code

```
function getScrollTop() {
    return targetEl[0] === $window ? $window.pageYOffset : targetEl[0] === $window;
}
```

What it should be

```
function getScrollTop() {
    return targetEl[0] === $window ? $window.pageYOffset : targetEl[0].scrollTop;
}
```
