### PR TITLE
Add support for empty placeholder on bs-select

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -235,7 +235,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
       link: function postLink(scope, element, attr, controller) {
 
         // Directive options
-        var options = {scope: scope};
+        var options = {scope: scope, placeholder: defaults.placeholder};
         angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'multiple', 'allNoneButtons', 'maxLength', 'maxLengthHtml'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
@@ -290,7 +290,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
             index = select.$getIndex(controller.$modelValue);
             selected = angular.isDefined(index) ? select.$scope.$matches[index].label : false;
           }
-          element.html((selected ? selected : attr.placeholder || defaults.placeholder) + defaults.caretHtml);
+          element.html((selected ? selected : options.placeholder) + defaults.caretHtml);
         };
 
         // Garbage collection


### PR DESCRIPTION
When placeholder is empty (including &nbsp; and space), it is overwritten by default without any way to actually have empty string.
This patch fixes the issue.
