### PR TITLE
Fixed issue when $tooltip.show is being called right after tooltip creation

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -141,6 +141,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             });
           }
 
+          // Reset show() for normal operation
+          $tooltip.show = $tooltip.$show;
         };
 
         $tooltip.destroy = function() {
@@ -186,7 +188,14 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         };
 
+        // Pre-init show implementation
         $tooltip.show = function() {
+            $tooltip.$promise.then(function() {
+                $tooltip.$show();
+            });
+        };
+
+        $tooltip.$show = function() {
 
           scope.$emit(options.prefixEvent + '.show.before', $tooltip);
           var parent = options.container ? tipContainer : null;


### PR DESCRIPTION
When tooltip is initialized using $tooltip service, and show is being called before template was loaded, NullPtr exception occurs during show. Its caused by tipLinker function not being yet initialized.
I fixed the issue by wrapping the actual show function in temporary one, which fires real show when template promise is being resolved. During init, show method is restored to original "full" one.
