### PR TITLE
Fixed issue when $tooltip.show is being called right after tooltip creation

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -187,6 +187,14 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
         };
 
         $tooltip.show = function() {
+          // Check, whether template is loaded
+          if (!tipLinker) {
+              // Post-pone show till template is loaded
+              $tooltip.$promise.then(function() {
+                  $tooltip.show();
+              });
+              return;
+          }
 
           scope.$emit(options.prefixEvent + '.show.before', $tooltip);
           var parent = options.container ? tipContainer : null;


### PR DESCRIPTION
A bit dirty fix, that avoids NullPointerException, when show is being called before template is loaded.
Occurs when creating tooltip using service and calling show on it, but can happen whenever template would be loaded from internet and not cache.
