### PR TITLE
feat(tabs): add support for setting basic bootstrap tab-types and tab-styles via directive attributes

### DIFF
--- a/src/tab/docs/tab.demo.html
+++ b/src/tab/docs/tab.demo.html
@@ -19,6 +19,10 @@ $scope.tabs.activeTab = {{ tabs.activeTab }};
       <div ng-repeat="tab in tabs" title="{{ tab.title }}" ng-bind="tab.content" bs-pane></div>
     </div>
   </div>
+  <div class="bs-example" append-source>
+    <!-- ngModel is optional -->
+    <div ng-model="tabs.activeTab" bs-tabs="tabs" data-use-pills="1" data-justified="1"></div>
+  </div>
   <div class="bs-example" style="padding-bottom: 24px;" append-source>
     <!-- control a tab with ngModel -->
     <div class="btn-group" ng-model="tabs.activeTab" bs-radio-group>

--- a/src/tab/tab.js
+++ b/src/tab/tab.js
@@ -65,6 +65,19 @@ angular.module('mgcrea.ngStrap.tab', [])
         // Add base class
         element.addClass('tabs');
 
+        // Evaluate template modifiers against appropriate scope
+        angular.forEach(['usePills', 'justified', 'stacked'], function (attr) {
+          if (angular.isDefined(attrs[attr])) scope['$'+attr] = scope.$eval(attrs[attr]);
+        });
+
+        // Define template ngClass config object
+        scope.$classConfig = {
+          'nav-tabs': !scope.$usePills,
+          'nav-pills': scope.$usePills,
+          'nav-justified': scope.$justified,
+          'nav-stacked': scope.$usePills && scope.$stacked
+        };
+
         if(ngModelCtrl) {
 
           // Update the modelValue following

--- a/src/tab/tab.tpl.html
+++ b/src/tab/tab.tpl.html
@@ -1,4 +1,4 @@
-<ul class="nav nav-tabs" role="tablist">
+<ul class="nav" role="tablist" ng-class="$classConfig">
   <li ng-repeat="$pane in $panes" ng-class="{active: $index == $panes.$active}">
     <a role="tab" data-toggle="tab" ng-click="$setActive($index)" data-index="{{ $index }}" ng-bind-html="$pane.title"></a>
   </li>

--- a/src/tab/test/tab.spec.js
+++ b/src/tab/test/tab.spec.js
@@ -33,6 +33,18 @@ describe('tab', function () {
       ]},
       element: '<div bs-tabs><div ng-repeat="tab in tabs" title="{{ tab.title }}" ng-bind="tab.content" bs-pane></div>'
     },
+    'template-usePills': {
+      element: '<div bs-tabs="tabs" data-use-pills="1"></div>'
+    },
+    'template-justified': {
+      element: '<div bs-tabs="tabs" data-justified="1"></div>'
+    },
+    'template-stacked': {
+      element: '<div bs-tabs="tabs" data-stacked="1"></div>'
+    },
+    'template-pills-stacked': {
+      element: '<div bs-tabs="tabs" data-use-pills="1" data-stacked="1"></div>'
+    },
     'binding-ngModel': {
       scope: {tab: {active: 1}},
       element: '<div ng-model="tab.active" bs-tabs><div title="title-1" bs-pane>content-1</div><div title="title-2" bs-pane>content-2</div></div>'
@@ -100,6 +112,36 @@ describe('tab', function () {
       sandboxEl.find('.nav-tabs > li:eq(0) > a').triggerHandler('click');
       expect(sandboxEl.find('.nav-tabs > li.active').text()).toBe(scope.tabs[0].title);
       expect(sandboxEl.find('.tab-content > .tab-pane.active').text()).toBe(scope.tabs[0].content);
+    });
+
+  });
+
+  describe('with template modifiers', function () {
+
+    it('should correctly apply `.nav-pills` to container el', function() {
+      var elm = compileDirective('template-usePills');
+      expect(sandboxEl.find('.nav-tabs').length).toBe(0);
+      expect(sandboxEl.find('.nav-pills').length).toBe(1);
+    });
+
+    it('should correctly apply `.nav-justified` to container el', function() {
+      var elm = compileDirective('template-justified');
+      expect(sandboxEl.find('.nav-tabs').length).toBe(1);
+      expect(sandboxEl.find('.nav-justified').length).toBe(1);
+    });
+
+    it('should correctly apply `.nav-stacked` if `attrs.usePills` truthy', function() {
+      var elm = compileDirective('template-pills-stacked');
+      expect(sandboxEl.find('.nav-tabs').length).toBe(0);
+      expect(sandboxEl.find('.nav-pills').length).toBe(1);
+      expect(sandboxEl.find('.nav-stacked').length).toBe(1);
+    });
+
+    it('should not apply `.nav-stacked` when `attrs.usePills` falsey', function() {
+      var elm = compileDirective('template-stacked');
+      expect(sandboxEl.find('.nav-tabs').length).toBe(1);
+      expect(sandboxEl.find('.nav-pills').length).toBe(0);
+      expect(sandboxEl.find('.nav-stacked').length).toBe(0);
     });
 
   });


### PR DESCRIPTION
This change improves the flexibility of `bs-tabs` without affecting default behavior, by allowing the directive to be configured (via directive attributes) to render as any allowable combination (see below) of bootstrap's `nav` components. The `bs-tabs` directive now supports using `nav-pills` instead of `nav-tabs` by setting the directive attribute `data-use-pills` to a truthy value.  Additionally, you may declare that either tabs or pills be `nav-justified` when `data-justified` evaluates to "truthy".

Attributes are evaluated against the appropriate scope, so they don't need to be hard-coded (if, for some reason, this result needs to be produced conditionally). 

Finally, if both `data-use-pills` AND `data-stacked` evaluate to "truthy", then pills will be stacked instead of inline (doesn't work for tabs, as that wouldn't make much sense... Technically, it is possible to stack tabs, but I haven't allowed it).

I think this is a useful change in that it makes the basic bootstrap "nav-tab" and "nav-pills" configurations accessible without requiring a custom template, though it will provide the same functionality to a custom template, if necessary. 
