### PR TITLE
fix(debounce): use  for deferring tasks

### DIFF
--- a/src/helpers/debounce.js
+++ b/src/helpers/debounce.js
@@ -4,58 +4,52 @@ angular.module('mgcrea.ngStrap.helpers.debounce', [])
 
 // @source jashkenas/underscore
 // @url https://github.com/jashkenas/underscore/blob/1.5.2/underscore.js#L693
-.constant('debounce', function(func, wait, immediate) {
-  var timeout, args, context, timestamp, result;
-  return function() {
-    context = this;
-    args = arguments;
-    timestamp = new Date();
-    var later = function() {
-      var last = (new Date()) - timestamp;
-      if (last < wait) {
-        timeout = setTimeout(later, wait - last);
-      } else {
-        timeout = null;
-        if (!immediate) result = func.apply(context, args);
+.factory('debounce', function($timeout) {
+  return function(func, wait, immediate) {
+    var timeout = null;
+    return function() {
+      var context = this,
+        args = arguments,
+        callNow = immediate && !timeout;
+      if(timeout) {
+        $timeout.cancel(timeout);
       }
+      timeout = $timeout(function later() {
+        timeout = null;
+        if(!immediate) {
+          func.apply(context, args);
+        }
+      }, wait, false);
+      if(callNow) {
+        func.apply(context, args);
+      }
+      return timeout;
     };
-    var callNow = immediate && !timeout;
-    if (!timeout) {
-      timeout = setTimeout(later, wait);
-    }
-    if (callNow) result = func.apply(context, args);
-    return result;
   };
 })
 
 
 // @source jashkenas/underscore
 // @url https://github.com/jashkenas/underscore/blob/1.5.2/underscore.js#L661
-.constant('throttle', function(func, wait, options) {
-  var context, args, result;
-  var timeout = null;
-  var previous = 0;
-  options || (options = {});
-  var later = function() {
-    previous = options.leading === false ? 0 : new Date();
-    timeout = null;
-    result = func.apply(context, args);
-  };
-  return function() {
-    var now = new Date();
-    if (!previous && options.leading === false) previous = now;
-    var remaining = wait - (now - previous);
-    context = this;
-    args = arguments;
-    if (remaining <= 0) {
-      clearTimeout(timeout);
-      timeout = null;
-      previous = now;
-      result = func.apply(context, args);
-    } else if (!timeout && options.trailing !== false) {
-      timeout = setTimeout(later, remaining);
-    }
-    return result;
+.factory('throttle', function($timeout) {
+  return function(func, wait, options) {
+    var timeout = null;
+    options || (options = {});
+    return function() {
+      var context = this,
+        args = arguments;
+      if(!timeout) {
+        if(options.leading !== false) {
+          func.apply(context, args);
+        }
+        timeout = $timeout(function later() {
+          timeout = null;
+          if(options.trailing !== false) {
+            func.apply(context, args);
+          }
+        }, wait, false);
+      }
+    };
   };
 });
 

--- a/src/helpers/test/debounce.spec.js
+++ b/src/helpers/test/debounce.spec.js
@@ -2,13 +2,14 @@
 
 describe('debounce', function() {
 
-  var $compile, scope, debounce, throttle;
+  var $compile, $timeout, scope, debounce, throttle;
 
   beforeEach(module('mgcrea.ngStrap.helpers.debounce'));
 
-  beforeEach(inject(function(_$rootScope_, _$compile_, _debounce_, _throttle_) {
+  beforeEach(inject(function(_$rootScope_, _$compile_, _$timeout_, _debounce_, _throttle_) {
     scope = _$rootScope_;
     $compile = _$compile_;
+    $timeout = _$timeout_;
     debounce = _debounce_;
     throttle = _throttle_;
   }));
@@ -17,34 +18,30 @@ describe('debounce', function() {
 
   describe('debounce', function() {
 
-    it('should correctly debounce a function', function(done) {
+    it('should correctly debounce a function', function() {
       var counter = 0;
       var incr = function() { counter++; };
       var debouncedIncr = debounce(incr, 12);
       debouncedIncr();
       debouncedIncr();
       expect(counter).toBe(0);
-      setTimeout(function() {
-        expect(counter).toBe(1);
-        done();
-      }, 12);
+      $timeout.flush();
+      expect(counter).toBe(1);
     });
 
   });
 
   describe('throttle', function() {
 
-    it('should correctly throttle a function', function(done) {
+    it('should correctly throttle a function', function() {
       var counter = 0;
       var incr = function() { counter++; };
       var throttledIncr = throttle(incr, 12);
       throttledIncr();
       throttledIncr();
       expect(counter).toBe(1);
-      setTimeout(function() {
-        expect(counter).toBe(2);
-        done();
-      }, 12);
+      $timeout.flush();
+      expect(counter).toBe(2);
     });
 
   });


### PR DESCRIPTION
I've completely rewritten debouncing function for binding it with `$timeout` service from angular core.
Now there is no need to call `$scope.$apply()` inside debounced functions.
Moreover, you can now write synchronous tests, which does they more cleaner
