### PR TITLE
fix(datepicker): Set native mobile date format after loading datepicker options (fixes #617)

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -264,11 +264,11 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
           newValue === true ? datepicker.show() : datepicker.hide();
         });
 
-        // Set expected iOS format
-        if(isNative && options.useNative) options.dateFormat = 'yyyy-MM-dd';
         // Initialize datepicker
         var datepicker = $datepicker(element, controller, options);
         options = datepicker.$options;
+        // Set expected iOS format
+        if(isNative && options.useNative) options.dateFormat = 'yyyy-MM-dd';
 
         // Observe attributes for changes
         angular.forEach(['minDate', 'maxDate'], function(key) {


### PR DESCRIPTION
This fixes an issue where the `useNative` option specified by the user was not defined as the options weren't loaded yet, meaning that the `dateFormat` wasn't reconfigured for mobile devices, and date parsing then failed.
