### PR TITLE
feat(modal): provide ability to cancel modal show/hide

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -117,7 +117,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.show = function() {
 
-          scope.$emit(options.prefixEvent + '.show.before', $modal);
+          if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
+            return;
+          }
           var parent;
           if(angular.isElement(options.container)) {
             parent = options.container;
@@ -178,7 +180,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.hide = function() {
 
-          scope.$emit(options.prefixEvent + '.hide.before', $modal);
+          if(scope.$emit(options.prefixEvent + '.hide.before', $modal).defaultPrevented) {
+            return;
+          }
           var promise = $animate.leave(modalElement, leaveAnimateCallback);
           // Support v1.3+ $animate
           // https://github.com/angular/angular.js/commit/bf0f5502b1bbfddc5cdd2f138efd9188b8c652a9

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -3,13 +3,14 @@
 describe('modal', function() {
 
   var bodyEl = $('body'), sandboxEl;
-  var $compile, $templateCache, $modal, $animate, scope;
+  var $compile, $templateCache, $modal, $animate, $rootScope, scope;
 
   beforeEach(module('ngSanitize'));
   beforeEach(module('ngAnimateMock'));
   beforeEach(module('mgcrea.ngStrap.modal'));
 
   beforeEach(inject(function (_$rootScope_, _$compile_, _$templateCache_, _$modal_, _$animate_) {
+    $rootScope = _$rootScope_;
     scope = _$rootScope_.$new();
     bodyEl.html('');
     sandboxEl = $('<div>').attr('id', 'sandbox').appendTo(bodyEl);
@@ -156,7 +157,7 @@ describe('modal', function() {
 
     it('should dispatch show and show.before events', function() {
       var myModal = $modal(templates['default'].scope.modal);
-      var emit = spyOn(myModal.$scope, '$emit');
+      var emit = spyOn(myModal.$scope, '$emit').andCallThrough();
       scope.$digest();
 
       expect(emit).toHaveBeenCalledWith('modal.show.before', myModal);
@@ -169,7 +170,7 @@ describe('modal', function() {
     it('should dispatch hide and hide.before events', function() {
       var myModal = $modal(templates['default'].scope.modal);
       scope.$digest();
-      var emit = spyOn(myModal.$scope, '$emit');
+      var emit = spyOn(myModal.$scope, '$emit').andCallThrough();
       myModal.hide();
 
       expect(emit).toHaveBeenCalledWith('modal.hide.before', myModal);
@@ -181,7 +182,7 @@ describe('modal', function() {
 
     it('should namespace show/hide events using the prefixEvent', function() {
       var myModal = $modal(angular.extend({prefixEvent: 'alert'}, templates['default'].scope.modal));
-      var emit = spyOn(myModal.$scope, '$emit');
+      var emit = spyOn(myModal.$scope, '$emit').andCallThrough();
       scope.$digest();
       myModal.hide();
       $animate.triggerCallbacks();
@@ -192,6 +193,30 @@ describe('modal', function() {
       expect(emit).toHaveBeenCalledWith('alert.hide', myModal);
     });
 
+    it("should can cancel show on show.before event", function() {
+      $rootScope.$on('modal.show.before', function(e) {
+        e.preventDefault();
+      });
+      $rootScope.$on('modal.show', function() {
+        throw new Error('modal should not be shown');
+      });
+      var myModal = $modal(templates['default'].scope.modal);
+      scope.$digest();  
+      $animate.triggerCallbacks();
+    });
+
+    it("should can cancel hide on hide.before event", function() {
+      $rootScope.$on('modal.hide.before', function(e) {
+        e.preventDefault();
+      });
+      $rootScope.$on('modal.hide', function() {
+        throw new Error('modal should not be hidden');
+      });
+      var myModal = $modal(templates['default'].scope.modal);
+      scope.$digest();  
+      myModal.hide();
+      $animate.triggerCallbacks();
+    });
   });
 
   describe('options', function() {


### PR DESCRIPTION
This fix makes possible to cancel the process of showing/hiding of modals. 
Inspired by  `$location` service and its event `$locationChangeStart`.
