### PR TITLE
feat(collapse): add startCollapsed option

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -7,7 +7,8 @@ angular.module('mgcrea.ngStrap.collapse', [])
     var defaults = this.defaults = {
       animation: 'am-collapse',
       disallowToggle: false,
-      activeClass: 'in'
+      activeClass: 'in',
+      startCollapsed: false
     };
 
     var controller = this.controller = function($scope, $element, $attrs) {
@@ -15,7 +16,7 @@ angular.module('mgcrea.ngStrap.collapse', [])
 
       // Attributes options
       self.$options = angular.copy(defaults);
-      angular.forEach(['animation', 'disallowToggle', 'activeClass'], function(key) {
+      angular.forEach(['animation', 'disallowToggle', 'activeClass', 'startCollapsed'], function (key) {
         if(angular.isDefined($attrs[key])) self.$options[key] = $attrs[key];
       });
 
@@ -31,7 +32,7 @@ angular.module('mgcrea.ngStrap.collapse', [])
         self.$targets.push(element);
       };
 
-      self.$targets.$active = 0;
+      self.$targets.$active = !self.$options.startCollapsed ? 0 : -1;
       self.$setActive = $scope.$setActive = function(value) {
         if(!self.$options.disallowToggle) {
           self.$targets.$active = self.$targets.$active === value ? -1 : value;

--- a/src/collapse/docs/collapse.demo.html
+++ b/src/collapse/docs/collapse.demo.html
@@ -104,6 +104,14 @@ $scope.panels.activePanel = {{ panels.activePanel }};
             <p>Disallow double-click toggling behavior</p>
           </td>
         </tr>
+        <tr>
+          <td>startCollapsed</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Start with all elements collapsed</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/collapse/test/collapse.spec.js
+++ b/src/collapse/test/collapse.spec.js
@@ -48,6 +48,9 @@ describe('tab', function () {
     },
     'options-disallowToggle': {
       element: '<div data-disallow-toggle="true" class="panel-group" bs-collapse><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-1</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-1</div></div></div><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-2</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-2</div></div></div></div>'
+    },
+    'options-startCollapsed': {
+      element: '<div data-start-collapsed="true" class="panel-group" bs-collapse><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-1</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-1</div></div></div><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-2</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-2</div></div></div></div>'
     }
   };
 
@@ -142,6 +145,19 @@ describe('tab', function () {
         expect(sandboxEl.find('[bs-collapse-target]:eq(0)').hasClass('in')).toBeTruthy();
         sandboxEl.find('[bs-collapse-toggle]:eq(0)').triggerHandler('click');
         expect(sandboxEl.find('[bs-collapse-target]:eq(0)').hasClass('in')).toBeTruthy();
+      });
+
+    });
+
+    describe('startCollapsed', function () {
+
+      it('should support startCollapsed flag', function() {
+        var elm = compileDirective('options-startCollapsed');
+        expect(sandboxEl.find('[bs-collapse-target]').hasClass('in')).toBeFalsy();
+        sandboxEl.find('[bs-collapse-toggle]:eq(0)').triggerHandler('click');
+        expect(sandboxEl.find('[bs-collapse-target]:eq(0)').hasClass('in')).toBeTruthy();
+        sandboxEl.find('[bs-collapse-toggle]:eq(0)').triggerHandler('click');
+        expect(sandboxEl.find('[bs-collapse-target]:eq(0)').hasClass('in')).toBeFalsy();
       });
 
     });


### PR DESCRIPTION
When doing the bootstrap collapse navbar, needed a way to start with the menu items collapsed when loading the page, so I added a new option to the bs-collapse directive. By default, it has the same behaviour as before.
