### PR TITLE
test(collapse): add test for ngModel initial value equal to default value

### DIFF
--- a/src/collapse/collapse.js
+++ b/src/collapse/collapse.js
@@ -77,7 +77,9 @@ angular.module('mgcrea.ngStrap.collapse', [])
           // modelValue -> $formatters -> viewValue
           ngModelCtrl.$formatters.push(function(modelValue) {
             // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
-            bsCollapseCtrl.$setActive(modelValue * 1);
+            if (bsCollapseCtrl.$targets.$active !== modelValue * 1) {
+              bsCollapseCtrl.$setActive(modelValue * 1);
+            }
             return modelValue;
           });
 

--- a/src/collapse/test/collapse.spec.js
+++ b/src/collapse/test/collapse.spec.js
@@ -40,10 +40,6 @@ describe('tab', function () {
       scope: {panel: {active: 1}},
       element: '<div class="panel-group" ng-model="panel.active" bs-collapse><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-1</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-1</div></div></div><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-2</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-2</div></div></div></div>'
     },
-    'binding-ngModel-zero': {
-      scope: {panel: {active: 0}},
-      element: '<div class="panel-group" ng-model="panel.active" bs-collapse><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-1</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-1</div></div></div><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-2</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-2</div></div></div></div>'
-    },
     'options-animation': {
       element: '<div data-animation="am-flip-x" class="panel-group" bs-collapse><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-1</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-1</div></div></div><div class="panel panel-default"><div class="panel-heading"><h4 class="panel-title"><a bs-collapse-toggle>title-2</a></h4></div><div class="panel-collapse" bs-collapse-target><div class="panel-body">content-2</div></div></div></div>'
     },
@@ -112,7 +108,7 @@ describe('tab', function () {
     });
 
     it('should correctly apply model when initial binding value equals default view value', function() {
-      var elm = compileDirective('binding-ngModel-zero');
+      var elm = compileDirective('binding-ngModel', { panel: { active: 0 } });
       expect(scope.panel.active).toBe(0);
     });
 


### PR DESCRIPTION
When the ngModel value is zero and we are using the default options (meaning, disallowToggle is false), the binding value will make the first panel toogle because it is equal to the default value. This means the ngModel will be set to -1.

Don't know how to solve this one, just came up when I was checking another thing.
