### PR TITLE
test(collapse): set scope model initial values at start of tests

### DIFF
--- a/src/collapse/test/collapse.spec.js
+++ b/src/collapse/test/collapse.spec.js
@@ -94,7 +94,8 @@ describe('tab', function () {
   describe('data-binding', function() {
 
     it('should correctly apply model changes to the view', function() {
-      var elm = compileDirective('binding-ngModel');
+      var elm = compileDirective('binding-ngModel', { panel: { active: 1 } });
+      expect(scope.panel.active).toBe(1);
       expect(sandboxEl.find('[bs-collapse-target].in').parent('.panel-default').index()).toBe(scope.panel.active);
       scope.panel.active = 0;
       scope.$digest();
@@ -102,7 +103,8 @@ describe('tab', function () {
     });
 
     it('should correctly apply view changes to the model', function() {
-      var elm = compileDirective('binding-ngModel');
+      var elm = compileDirective('binding-ngModel', { panel: { active: 1 } });
+      expect(scope.panel.active).toBe(1);
       sandboxEl.find('[bs-collapse-toggle]:eq(0)').triggerHandler('click');
       expect(scope.panel.active).toBe(0);
     });


### PR DESCRIPTION
The data-binding tests are using the same shared template, including the scope definition, which makes the previous test affect the next one because they are referencing the same object.

This was not being detected because the test didn't check the scope value at start of test.

I changed the collapse tests initialization to explicitly set the scope values we are interested in.

Maybe this also happens in other modules tests?
