### PR TITLE
docs(alert): fix typo with documentation for dismissable

### DIFF
--- a/src/alert/docs/alert.demo.html
+++ b/src/alert/docs/alert.demo.html
@@ -142,11 +142,11 @@
           </td>
         </tr>
         <tr>
-          <td>dissmissable</td>
+          <td>dismissable</td>
           <td>boolean</td>
           <td>true</td>
           <td>
-            <p>Make the alert dissmissable by adding a close button (&times;).</p>
+            <p>Make the alert dismissable by adding a close button (&times;).</p>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
It took me awhile to figure out why I couldn't get my alert to be non-dismisable.  I've updated the documents to have the correct spelling.
