### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Clone the repo, `git clone git://github.com/mgcrea/angular-strap.git`, [download
 AngularStrap is tested with `karma` against the latest stable release of AngularJS.
 
 >
-	$ npm install --dev
+	$ npm install
 	$ gulp test
 
 You can build the latest version using `gulp`.


### PR DESCRIPTION
--dev is marked for deprecation. I was unable to install the node modules using `npm install --dev` because it installs the devDependencies recursively, and my machine failed at that. `npm install` will will install devDependencies (except on production). See [this issue](https://github.com/npm/npm/issues/6137#issuecomment-55733852) for discussion.
