### PR TITLE
fix(timepicker): ignore switch meridian when time value is not defined

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -188,6 +188,17 @@ describe('timepicker', function() {
       expect(angular.isDate(scope.selectedUndefined)).toBeTruthy();
     });
 
+    it('should ignore switch meridians with undefined time values', function() {
+      var elm = compileDirective('value-undefined');
+      expect(elm.val()).toBe('');
+      angular.element(elm[0]).triggerHandler('focus');
+      var amButton = angular.element(sandboxEl.find('.dropdown-menu tbody td:eq(4) button:eq(0)')[0]);
+      spyOn(scope.$$childHead, '$switchMeridian');
+      amButton.triggerHandler('click');
+      // expect not to throw exception
+      expect(scope.$$childHead.$switchMeridian).toHaveBeenCalled();
+    });
+
     it('should correctly support invalid values', function() {
       var elm = compileDirective('default');
       elm.val('invalid');

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -94,6 +94,9 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         };
 
         $timepicker.switchMeridian = function(date) {
+          if (!controller.$dateValue || isNaN(controller.$dateValue.getTime())) {
+            return;
+          }
           var hours = (date || controller.$dateValue).getHours();
           controller.$dateValue.setHours(hours < 12 ? hours + 12 : hours - 12);
           controller.$setViewValue(controller.$dateValue);


### PR DESCRIPTION
Fix for issue #1089
