### PR TITLE
fix(affix): apply original element CSS position after calculations

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -122,7 +122,7 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
         $affix.$debouncedOnResize = debounce($affix.$onResize, 50);
 
         $affix.$parseOffsets = function() {
-
+          var initialPosition = element.css('position');
           // Reset position to calculate correct offsetTop
           element.css('position', (options.offsetParent) ? '' : 'relative');
 
@@ -154,6 +154,8 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
             }
           }
 
+          // Bring back the element's position after calculations
+          element.css('position', initialPosition);
         };
 
         // Private methods


### PR DESCRIPTION
Hi there,

here is a fix for the affix plugin. The bug is easy to reproduce, for example on your website http://mgcrea.github.io/angular-strap/##affix : just change the browser window dimensions using the mouse, and you'll see your left menu disappear.

This fix applies back the affixed element "position" CSS after post resize calculations are done.

Hope you'll like it (and merge it ;)
