### PR TITLE
fix(timepicker): fix setting empty minTime/maxTime

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -459,6 +459,15 @@ describe('timepicker', function() {
         // expect(sandboxEl.find('.dropdown-menu tbody button:contains(' + (todayHour - 1) + ')').is(':disabled')).toBeTruthy();
       });
 
+      it('should consider empty minTime as no minTime defined', function() {
+        var elm = compileDirective('options-minTime');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(8)').is(':disabled')).toBeTruthy();
+        scope.minTime = '';
+        scope.$digest();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(8)').is(':disabled')).toBeFalsy();
+      });
+
       it('should validate using minTime', function() {
         var elm = compileDirective('options-minTime');
 
@@ -492,6 +501,16 @@ describe('timepicker', function() {
         // expect(sandboxEl.find('.dropdown-menu tbody button:contains(' + (todayHour + 1) + ')').is(':disabled')).toBeTruthy();
       });
 
+      it('should consider empty maxTime as no maxTime defined', function() {
+        var elm = compileDirective('options-maxTime');
+        angular.element(elm[0]).triggerHandler('focus');
+        scope.maxTime = '10:30 AM';
+        scope.$digest();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(11)').is(':disabled')).toBeTruthy();
+        scope.maxTime = '';
+        scope.$digest();
+        expect(sandboxEl.find('.dropdown-menu tbody button:contains(11)').is(':disabled')).toBeFalsy();
+      });
 
       it('should validate using maxTime', function() {
         var elm = compileDirective('options-maxTime');

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -354,7 +354,9 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
               timepicker.$options[key] = new Date().setFullYear(1970, 0, 1);
             } else if(angular.isString(newValue) && newValue.match(/^".+"$/)) {
               timepicker.$options[key] = +new Date(newValue.substr(1, newValue.length - 2));
-            } else {
+            } else if(newValue === '') {
+              timepicker.$options[key] = key === 'minTime' ? -Infinity : +Infinity;
+            } else { 
               timepicker.$options[key] = +dateParser.parse(newValue, new Date(1970, 0, 1, 0));
             }
             !isNaN(timepicker.$options[key]) && timepicker.$build();


### PR DESCRIPTION
When minTime or maxTime is binded to an empty string, treat it like there is no limit defined. 
I think it should fix #1062.
