### PR TITLE
fix(datepicker): fix startDate attribute with a date object

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -423,6 +423,11 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
         var weekDaysLabels = weekDaysMin.slice(options.startWeek).concat(weekDaysMin.slice(0, options.startWeek));
         var weekDaysLabelsHtml = $sce.trustAsHtml('<th class="dow text-center">' + weekDaysLabels.join('</th><th class="dow text-center">') + '</th>');
 
+        // if startDate is defined, take out all quote characters,
+        // in case we are getting a JSON serialized date string.
+        // This happens when the property is binded to a date object value.
+        if (options.startDate) options.startDate = options.startDate.replace(/"/g, '');
+
         var startDate = picker.$date || (options.startDate ? new Date(options.startDate) : new Date());
         var viewDate = {year: startDate.getFullYear(), month: startDate.getMonth(), date: startDate.getDate()};
         var timezoneOffset = startDate.getTimezoneOffset() * 6e4;

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -692,6 +692,12 @@ describe('datepicker', function() {
         expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(new Date(scope.startDate), 'MMMM yyyy'));
       });
 
+      it('should support a dynamic startDate from date object', function() {
+        var elm = compileDirective('options-startDate', {startDate: new Date(2014, 2, 2)});
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(scope.startDate, 'MMMM yyyy'));
+      });
+
     });
 
     describe('useNative', function() {


### PR DESCRIPTION
Fix for issue #1118. 
If we use a date object in the attribute binding, angular will convert the date object to a JSON date string with start and end quotes, so the fix just removes the quotes to allow the _new Date()_ to re-create the date value from the string.
