### PR TITLE
fix(datepicker): fix startDate attribute with a date object (alternative)

### DIFF
--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -692,6 +692,12 @@ describe('datepicker', function() {
         expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(new Date(scope.startDate), 'MMMM yyyy'));
       });
 
+      it('should support a dynamic startDate from date object', function() {
+        var elm = compileDirective('options-startDate', {startDate: new Date(2014, 2, 2)});
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(scope.startDate, 'MMMM yyyy'));
+      });
+
     });
 
     describe('useNative', function() {

--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -145,6 +145,43 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
         return date.toDate();
       };
 
+      $dateParser.getDateForAttribute = function(key, value) {
+        var date;
+
+        if(value === 'today') {
+          var today = new Date();
+          date = new Date(today.getFullYear(), today.getMonth(), today.getDate() + (key === 'maxDate' ? 1 : 0), 0, 0, 0, (key === 'minDate' ? 0 : -1));
+        } else if(angular.isString(value) && value.match(/^".+"$/)) { // Support {{ dateObj }}
+          date = new Date(value.substr(1, value.length - 2));
+        } else if(isNumeric(value)) {
+          date = new Date(parseInt(value, 10));
+        } else if (angular.isString(value) && 0 === value.length) { // Reset date
+          date = key === 'minDate' ? -Infinity : +Infinity;
+        } else {
+          date = new Date(value);
+        }
+
+        return date;
+      };
+
+      $dateParser.getTimeForAttribute = function(key, value) {
+        var time;
+
+        if(value === 'now') {
+          time = new Date().setFullYear(1970, 0, 1);
+        } else if(angular.isString(value) && value.match(/^".+"$/)) {
+          time = new Date(value.substr(1, value.length - 2));
+        } else if(isNumeric(value)) {
+          time = new Date(parseInt(value, 10));
+        } else if (angular.isString(value) && 0 === value.length) { // Reset time
+          time = key === 'minTime' ? -Infinity : +Infinity;
+        } else { 
+          time = $dateParser.parse(value, new Date(1970, 0, 1, 0));
+        }
+
+        return time;
+      };
+
       // Private functions
 
       function setMapForFormat(format) {

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -351,15 +351,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         angular.forEach(['minTime', 'maxTime'], function(key) {
           // console.warn('attr.$observe(%s)', key, attr[key]);
           angular.isDefined(attr[key]) && attr.$observe(key, function(newValue) {
-            if(newValue === 'now') {
-              timepicker.$options[key] = new Date().setFullYear(1970, 0, 1);
-            } else if(angular.isString(newValue) && newValue.match(/^".+"$/)) {
-              timepicker.$options[key] = +new Date(newValue.substr(1, newValue.length - 2));
-            } else if(newValue === '') {
-              timepicker.$options[key] = key === 'minTime' ? -Infinity : +Infinity;
-            } else { 
-              timepicker.$options[key] = +dateParser.parse(newValue, new Date(1970, 0, 1, 0));
-            }
+            timepicker.$options[key] = dateParser.getTimeForAttribute(key, newValue);
             !isNaN(timepicker.$options[key]) && timepicker.$build();
           });
         });


### PR DESCRIPTION
An alternative fix for the startDate usage with date object binding.
In this alternative, I have moved the date and time instancing from the attribute values into the dateparser so that the code can be uniform and called elsewhere.
