### PR TITLE
fix(button): convert exotic model values to boolean view value

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -67,6 +67,11 @@ angular.module('mgcrea.ngStrap.button', [])
             // console.warn('$parser', element.attr('ng-model'), 'viewValue', viewValue);
             return viewValue ? trueValue : falseValue;
           });
+          // modelValue -> $formatters -> viewValue
+          controller.$formatters.push(function(modelValue) {
+             // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
+             return angular.equals(modelValue, trueValue);
+          });
           // Fix rendering for exotic values
           scope.$watch(attr.ngModel, function(newValue, oldValue) {
             controller.$render();


### PR DESCRIPTION
Fix for AngularJS 1.3 breaking changes when using exotic values for checkbox. The view value for the input type checkbox needs to be a boolean?

This seems to be related to this commit:

https://github.com/angular/angular.js/commit/c90cefe16142d973a123e945fc9058e8a874c357

and changes to the ngTrueValue/ngFalseValue attributes behaviour.
