### PR TITLE
docs(getting-started): add Cloudflare CDN link to 'Getting Started'

### DIFF
--- a/docs/views/sections/getting-started.html
+++ b/docs/views/sections/getting-started.html
@@ -14,7 +14,7 @@
   </div>
 
   <h2 id="project-quickstart">Quick Start</h2>
-  <p>Install and manage AngularStrap with <a href="http://bower.io">Bower</a>. <small>You can also use <a href="https://www.nuget.org/packages/angular-strap">NuGet</a>.</small></p>
+  <p>Install and manage AngularStrap with <a href="http://bower.io">Bower</a>. <small>You can also use <a href="https://www.nuget.org/packages/angular-strap">NuGet</a>.</small> A <a href="http://cdnjs.com/libraries/angular-strap">CDN</a> is also provided by cdnjs.com.</p>
   <div class="highlight">
     <pre>
       <code class="bash" highlight-block>
@@ -27,7 +27,9 @@
   <div class="highlight">
     <pre>
       <code class="html" highlight-block>
-        &lt;script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.9/angular.min.js"&gt;&lt;/script&gt; &lt;script src="bower_components/angular-strap/dist/angular-strap.min.js"&gt;&lt;/script&gt; &lt;script src="bower_components/angular-strap/dist/angular-strap.tpl.min.js"&gt;&lt;/script&gt;
+        &lt;script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.9/angular.min.js"&gt;&lt;/script&gt;
+        &lt;script src="bower_components/angular-strap/dist/angular-strap.min.js"&gt;&lt;/script&gt;
+        &lt;script src="bower_components/angular-strap/dist/angular-strap.tpl.min.js"&gt;&lt;/script&gt;
       </code>
     </pre>
   </div>


### PR DESCRIPTION
Add a link to the Cloudflare CDN that can be helpful to beginners.

closes #1043
