### PR TITLE
fix(timepicker): fix auto-close error with angular 1.3 $animate

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -2,14 +2,14 @@
 
 describe('timepicker', function() {
 
-  var $compile, $templateCache, $animate, $timepicker, dateFilter, scope, sandboxEl, today;
+  var $compile, $templateCache, $animate, $timepicker, dateFilter, scope, sandboxEl, today, $timeout;
 
   beforeEach(module('ngAnimate'));
   beforeEach(module('ngAnimateMock'));
   beforeEach(module('ngSanitize'));
   beforeEach(module('mgcrea.ngStrap.timepicker'));
 
-  beforeEach(inject(function (_$rootScope_, _$compile_, _$templateCache_, _$animate_, _$timepicker_, _dateFilter_) {
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$templateCache_, _$animate_, _$timepicker_, _dateFilter_, _$timeout_) {
     scope = _$rootScope_.$new();
     sandboxEl = $('<div>').attr('id', 'sandbox').appendTo($('body'));
     $compile = _$compile_;
@@ -18,6 +18,7 @@ describe('timepicker', function() {
     $timepicker = _$timepicker_;
     dateFilter = _dateFilter_;
     today = new Date();
+    $timeout = _$timeout_;
   }));
 
   afterEach(function() {
@@ -361,6 +362,7 @@ describe('timepicker', function() {
         expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:first')).triggerHandler('click');
+        $timeout.flush();
         expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
       });
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -30,7 +30,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
       arrowBehavior: 'pager'
     };
 
-    this.$get = function($window, $document, $rootScope, $sce, $locale, dateFilter, $tooltip) {
+    this.$get = function($window, $document, $rootScope, $sce, $locale, dateFilter, $tooltip, $timeout) {
 
       var bodyEl = angular.element($window.document.body);
       var isNative = /(ip(a|o)d|iphone|android)/ig.test($window.navigator.userAgent);
@@ -89,7 +89,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           controller.$setViewValue(controller.$dateValue);
           controller.$render();
           if(options.autoclose && !keep) {
-            $timepicker.hide(true);
+            $timeout(function() { $timepicker.hide(true); });
           }
         };
 


### PR DESCRIPTION
timepicker's auto-close test is failing with angularjs 1.3 release. Looks like the error might be solved once angular merges pull request https://github.com/angular/angular.js/pull/9636, which introduces a check to avoid the exception.
Anyway, the close on blur test works, so something else is triggering the error. By calling the $timepicker.hide method inside a $timeout when auto-closing, the error goes away, so this seems a good fix.
