### PR TITLE
feat(affix): keep width of affixed element

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -23,6 +23,7 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
 
         // Initial private vars
         var reset = 'affix affix-top affix-bottom',
+            setWidth = false,
             initialAffixTop = 0,
             initialOffsetTop = 0,
             offsetTop = 0,
@@ -47,6 +48,7 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
 
           $affix.$parseOffsets();
           initialOffsetTop = dimensions.offset(element[0]).top + initialAffixTop;
+          setWidth = !element[0].style.width;
 
           // Bind events
           targetEl.on('scroll', $affix.checkPosition);
@@ -95,6 +97,9 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
           if(affix === 'top') {
             unpin = null;
             element.css('position', (options.offsetParent) ? '' : 'relative');
+            if(setWidth) {
+              element.css('width', '');
+            }
             element.css('top', '');
           } else if(affix === 'bottom') {
             if (options.offsetUnpin) {
@@ -105,10 +110,16 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
               // Hopefully the browser scrolls pixel by pixel.
               unpin = position.top - scrollTop;
             }
+            if(setWidth) {
+              element.css('width', '');
+            }
             element.css('position', (options.offsetParent) ? '' : 'relative');
             element.css('top', (options.offsetParent) ? '' : ((bodyEl[0].offsetHeight - offsetBottom - elementHeight - initialOffsetTop) + 'px'));
           } else { // affix === 'middle'
             unpin = null;
+            if(setWidth) {
+              element.css('width', element[0].offsetWidth + 'px');
+            }
             element.css('position', 'fixed');
             element.css('top', initialAffixTop + 'px');
           }

--- a/src/affix/test/affix.spec.js
+++ b/src/affix/test/affix.spec.js
@@ -16,9 +16,15 @@ describe('affix', function () {
 
   var templates = {
     'default': {
-      element: '<div class="container" style="height: 2000px">' +
-               '  <div style="height: 200px; background: blue;"></div>' +
-               '  <div style="width: 100px; height: 100px; background: red; margin-top:20px;" bs-affix data-offset-top="-50" data-offset-bottom="1000"></div>' +
+      element: '<div class="container" style="height: 200px;overflow: auto;" bs-affix-target>' +
+               '  <div style="height: 100px; background: red; margin-top:20px;" bs-affix data-offset-bottom="+250"></div>' +
+               '  <div style="height: 600px; background: blue;"></div>' +
+               '</div>'
+    },
+    'implicitWidth': {
+      element: '<div class="container" style="height: 200px;overflow: auto;" bs-affix-target>' +
+               '  <div style="width: 100px; height: 100px; background: red; margin-top:20px;" bs-affix data-offset-bottom="+250"></div>' +
+               '  <div style="height: 600px; background: blue;"></div>' +
                '</div>'
     }
   };
@@ -64,6 +70,47 @@ describe('affix', function () {
       expect(1).toBe(1);
     });
 
+    it('should set affix-top class on top of scroll', function() {
+      var scrollTarget = compileDirective('default');
+      var affix = scrollTarget.find('[bs-affix]');
+      expect(affix).toHaveClass('affix-top');
+      expect(affix).not.toHaveClass('affix');
+    });
+
+    it('should set affix class', function(done) {
+      var scrollTarget = compileDirective('default');
+      var affix = scrollTarget.find('[bs-affix]');
+      scrollTarget.scrollTop(50);
+
+      setTimeout(function() {
+        expect(affix).toHaveClass('affix');
+        done();
+      }, 0);
+    });
+
+    it('should keep width while affixed', function(done) {
+      var scrollTarget = compileDirective('default');
+      var affix = scrollTarget.find('[bs-affix]');
+      var width = affix.width();
+
+      expect(affix[0].style.width).toBe('');
+
+      scrollTarget.scrollTop(50);
+
+      setTimeout(function() {
+        expect(affix[0].style.width).toBe(width + 'px');
+        done();
+      }, 0);
+    });
+  });
+
+  describe('implicit width', function() {
+    it('should not remove width when it had been defined', function() {
+      var scrollTarget = compileDirective('implicitWidth');
+      var affix = scrollTarget.find('[bs-affix]');
+
+      expect(affix.css('width')).not.toBe('');
+    });
   });
 
 


### PR DESCRIPTION
While using affix directive I encountered with this issue.

Future css `position: sticky;` will constrain position of floating elements, but affix directive doesn't do it.
This fixes makes affix behaviour more similar to future styles. However, it respects previous behaviour, so that if you implicitly set the width of element, it won't be changed.

I've provided some tests to ensure that it works.
