### PR TITLE
fix(typeahead): show dropdown on focus when minLength is 0

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -316,6 +316,14 @@ describe('typeahead', function () {
       expect(scope.$$childHead.$isVisible).not.toThrow();
     });
 
+    it('should should show options on focus when minLength is 0', function() {
+      var elm = compileDirective('options-minLength', {}, function(scope) { delete scope.selectedState; });
+      angular.element(elm[0]).triggerHandler('focus');
+      scope.$digest();
+      expect(sandboxEl.find('.dropdown-menu li').length).toBe($typeahead.defaults.limit);
+      expect(scope.$$childHead.$isVisible()).toBeTruthy();
+    });
+
   });
 
 });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -226,7 +226,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         // modelValue -> $formatters -> viewValue
         controller.$formatters.push(function(modelValue) {
           // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
-          return parsedOptions.displayValue(modelValue);
+          var displayValue = parsedOptions.displayValue(modelValue);
+          return displayValue === undefined ? '' : displayValue;
         });
 
         // Model rendering in view


### PR DESCRIPTION
The first time the input control receives focus and minLegth was 0, the options dropdown was not showing. If you typed a character and then deleted it, then the dropdown would always show on focus. Turns out that the first time, the view value was undefined, so the internal $isVisible value was returning false. Fixed it by defaulting undefined display values to empty string.

Might be the cause for #1164.

This is happening on the docs page with the icons input.
