### PR TITLE
fix(typeahead): fix binding to numeric values

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -192,6 +192,15 @@ describe('typeahead', function () {
       expect(elm.val()).toBe(jQuery('<div></div>').html(scope.icons[0].fr_FR).text().trim());
     });
 
+    it('should support numeric values', function() {
+      var elm = compileDirective('default', { states: [1, 2, 3] });
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.dropdown-menu li:eq(0) a').html()).toBe('1');
+      angular.element(sandboxEl.find('.dropdown-menu li:eq(0) a').get(0)).triggerHandler('click');
+      expect(scope.selectedState).toBe(scope.states[0]);
+      expect(elm.val()).toBe(jQuery('div').html(scope.states[0]).text().trim());
+    });
+
   });
 
   describe('ngOptions', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -236,7 +236,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           var index = typeahead.$getIndex(controller.$modelValue);
           var selected = angular.isDefined(index) ? typeahead.$scope.$matches[index].label : controller.$viewValue;
           selected = angular.isObject(selected) ? selected.label : selected;
-          element.val(selected ? selected.replace(/<(?:.|\n)*?>/gm, '').trim() : '');
+          element.val(selected ? selected.toString().replace(/<(?:.|\n)*?>/gm, '').trim() : '');
         };
 
         // Garbage collection


### PR DESCRIPTION
When rendering view value, the code strips html tags from value assuming the value is a string. To fix, added a call to toString() before doing replace().

Fixes #705
