### PR TITLE
docs(tooltip): fix show/hide event names

### DIFF
--- a/src/modal/docs/modal.demo.html
+++ b/src/modal/docs/modal.demo.html
@@ -178,7 +178,7 @@
           <td>string</td>
           <td>'modal'</td>
           <td>
-            <p>If provided, prefixes the events '.hide' '.hide.after' '.show' and '.show.after' with the passed in value. With the default value these events are 'modal.hide' 'modal.hide.after' 'modal.show' and 'modal.show.after'</p>
+            <p>If provided, prefixes the events '.hide.before' '.hide' '.show.before' and '.show' with the passed in value. With the default value these events are 'modal.hide.before' 'modal.hide' 'modal.show.before' and 'modal.show'</p>
           </td>
         </tr>
       </tbody>

--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -155,7 +155,7 @@
           <td>string</td>
           <td>'tooltip'</td>
           <td>
-            <p>If provided, prefixes the events '.hide' '.hide.after' '.show' and '.show.after' with the passed in value. With the default value these events are 'tooltip.hide' 'tooltip.hide.after' 'tooltip.show' and 'tooltip.show.after'</p>
+            <p>If provided, prefixes the events '.hide.before' '.hide' '.show.before' and '.show' with the passed in value. With the default value these events are 'tooltip.hide.before' 'tooltip.hide' 'tooltip.show.before' and 'tooltip.show'</p>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
The events description for modal is also fixed

fixes #1032
