### PR TITLE
fix(timepicker): ignore ngModel date part when validating min/max time

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -574,6 +574,12 @@ describe('timepicker', function() {
         expect(elm.hasClass('ng-valid-min')).toBeTruthy();
       });
 
+      it('should ignore date part of ngModel when validating with minTime', function() {
+        var elm = compileDirective('options-minTime', { selectedTime: new Date(1957, 6, 13, 10, 30)});
+        angular.element(elm[0]).triggerHandler('change');
+        expect(elm.hasClass('ng-valid-min')).toBeTruthy();
+      });
+
     });
 
     describe('maxTime', function() {
@@ -649,6 +655,12 @@ describe('timepicker', function() {
 
         scope.maxTime = '11:00 PM'; // valid again
         scope.$digest();
+        expect(elm.hasClass('ng-valid-max')).toBeTruthy();
+      });
+
+      it('should ignore date part of ngModel when validating with maxTime', function() {
+        var elm = compileDirective('options-maxTime', { selectedTime: new Date(1987, 6, 13, 10, 30)});
+        angular.element(elm[0]).triggerHandler('change');
         expect(elm.hasClass('ng-valid-max')).toBeTruthy();
       });
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -365,8 +365,8 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         function validateAgainstMinMaxTime(parsedTime) {
           if (!angular.isDate(parsedTime)) return;
-          var isMinValid = isNaN(options.minTime) || parsedTime.getTime() >= options.minTime;
-          var isMaxValid = isNaN(options.maxTime) || parsedTime.getTime() <= options.maxTime;
+          var isMinValid = isNaN(options.minTime) || new Date(parsedTime.getTime()).setFullYear(1970, 0, 1) >= options.minTime;
+          var isMaxValid = isNaN(options.maxTime) || new Date(parsedTime.getTime()).setFullYear(1970, 0, 1) <= options.maxTime;
           var isValid = isMinValid && isMaxValid;
           controller.$setValidity('date', isValid);
           controller.$setValidity('min', isMinValid);


### PR DESCRIPTION
For validating the current time value against min/max time, it creates a new Date with date part set to Jan 1, 1970, which is the same as the min/max time values, so effectively, only the time part is compared.

should fix #1143
