### PR TITLE
affix: optional inline styles

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -5,7 +5,8 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
   .provider('$affix', function() {
 
     var defaults = this.defaults = {
-      offsetTop: 'auto'
+      offsetTop: 'auto',
+      inlineStyles: true
     };
 
     this.$get = function($window, debounce, dimensions) {
@@ -98,11 +99,13 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
 
           if(affix === 'top') {
             unpin = null;
-            element.css('position', (options.offsetParent) ? '' : 'relative');
             if(setWidth) {
               element.css('width', '');
             }
-            element.css('top', '');
+            if (options.inlineStyles) {
+              element.css('position', (options.offsetParent) ? '' : 'relative');
+              element.css('top', '');
+            }
           } else if(affix === 'bottom') {
             if (options.offsetUnpin) {
               unpin = -(options.offsetUnpin * 1);
@@ -115,15 +118,19 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
             if(setWidth) {
               element.css('width', '');
             }
-            element.css('position', (options.offsetParent) ? '' : 'relative');
-            element.css('top', (options.offsetParent) ? '' : ((bodyEl[0].offsetHeight - offsetBottom - elementHeight - initialOffsetTop) + 'px'));
+            if (options.inlineStyles) {
+              element.css('position', (options.offsetParent) ? '' : 'relative');
+              element.css('top', (options.offsetParent) ? '' : ((bodyEl[0].offsetHeight - offsetBottom - elementHeight - initialOffsetTop) + 'px'));
+            }
           } else { // affix === 'middle'
             unpin = null;
             if(setWidth) {
               element.css('width', element[0].offsetWidth + 'px');
             }
-            element.css('position', 'fixed');
-            element.css('top', initialAffixTop + 'px');
+            if (options.inlineStyles) {
+              element.css('position', 'fixed');
+              element.css('top', initialAffixTop + 'px');
+            }
           }
 
         };
@@ -137,7 +144,9 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
         $affix.$parseOffsets = function() {
           var initialPosition = element.css('position');
           // Reset position to calculate correct offsetTop
-          element.css('position', (options.offsetParent) ? '' : 'relative');
+          if (options.inlineStyles){
+            element.css('position', (options.offsetParent) ? '' : 'relative');
+          }
 
           if(options.offsetTop) {
             if(options.offsetTop === 'auto') {
@@ -168,7 +177,9 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
           }
 
           // Bring back the element's position after calculations
-          element.css('position', initialPosition);
+          if (options.inlineStyles){
+            element.css('position', initialPosition);
+          }
         };
 
         // Private methods
@@ -216,9 +227,14 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
       require: '^?bsAffixTarget',
       link: function postLink(scope, element, attr, affixTarget) {
 
-        var options = {scope: scope, offsetTop: 'auto', target: affixTarget ? affixTarget.$element : angular.element($window)};
-        angular.forEach(['offsetTop', 'offsetBottom', 'offsetParent', 'offsetUnpin'], function(key) {
-          if(angular.isDefined(attr[key])) options[key] = attr[key];
+        var options = {scope: scope, target: affixTarget ? affixTarget.$element : angular.element($window)};
+        angular.forEach(['offsetTop', 'offsetBottom', 'offsetParent', 'offsetUnpin', 'inlineStyles'], function(key) {
+          if(angular.isDefined(attr[key])) {
+            var option = attr[key];
+            if (/true/i.test(option)) option = true;
+            if (/false/i.test(option)) option = false;
+            options[key] = option;
+          }
         });
 
         var affix = $affix(element, options);

--- a/src/affix/test/affix.spec.js
+++ b/src/affix/test/affix.spec.js
@@ -26,6 +26,12 @@ describe('affix', function () {
                '  <div style="width: 100px; height: 100px; background: red; margin-top:20px;" bs-affix data-offset-bottom="+250"></div>' +
                '  <div style="height: 600px; background: blue;"></div>' +
                '</div>'
+    },
+    'noAddedInlineStyles': {
+      element: '<div class="container" style="height: 200px;overflow: auto;" bs-affix-target>' +
+               '  <div style="height: 100px; background: red; margin-top:20px;" bs-affix data-inline-styles="false" data-offset-bottom="+250"></div>' +
+               '  <div style="height: 600px; background: blue;"></div>' +
+               '</div>'
     }
   };
 
@@ -110,6 +116,31 @@ describe('affix', function () {
       var affix = scrollTarget.find('[bs-affix]');
 
       expect(affix.css('width')).not.toBe('');
+    });
+  });
+
+  describe('inline styles', function() {
+
+    beforeEach(module('ngSanitize'));
+    beforeEach(module('mgcrea.ngStrap.affix'));
+
+    beforeEach(inject(sandboxSetup));
+
+    it('should not have inline styling applied if inline-styles=false', function(done) {
+      var scrollTarget = compileDirective('noAddedInlineStyles');
+      var affix = scrollTarget.find('[bs-affix]');
+
+      expect(affix.css('position')).toBe('static');
+      expect(affix.css('top')).toBe('auto');
+
+      scrollTarget.scrollTop(50);
+
+      setTimeout(function() {
+        // styles are the same even after scrolling
+        expect(affix.css('position')).toBe('static');
+        expect(affix.css('top')).toBe('auto');
+        done();
+      }, 0);
     });
   });
 


### PR DESCRIPTION
Reference: #960 

I use the panel from affix on mobile (xs and sm), but don't want it to have an affix-behavior on mobile. The inline styles that are currently applied in .js make it near-impossible to use my own css (there's no room for a fixed sidebar/column).