### PR TITLE
feat(typeahead): expose ability to specify comparator

### DIFF
--- a/src/typeahead/docs/typeahead.demo.html
+++ b/src/typeahead/docs/typeahead.demo.html
@@ -145,6 +145,14 @@ $scope.selectedAddress = "{{selectedAddress}}";
             <p>The minimum character length needed before triggering autocomplete suggestions.</p>
           </td>
         </tr>
+        <tr>
+          <td>comparator</td>
+          <td>string</td>
+          <td>''</td>
+          <td>
+            <p>The name of the comparator function which is used in determining a match.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -38,6 +38,10 @@ describe('typeahead', function () {
       scope: {selectedCode: '', codes: ['000000', '000001']},
       element: '<input type="text" ng-model="selecteCode" ng-options="code for code in codes" bs-typeahead>'
     },
+    'comparator': {
+      scope: {selectedCode: '', codes: ['001000', '002001']},
+      element: '<input type="text" ng-model="selecteCode" ng-options="code for code in codes" bs-typeahead comparator="{{ comparator }}">'
+    },
     'markup-ngRepeat': {
       element: '<ul><li ng-repeat="i in [1, 2, 3]"><input type="text" ng-model="selectedState" ng-options="state for state in states" bs-typeahead></li></ul>'
     },
@@ -153,6 +157,29 @@ describe('typeahead', function () {
       expect(elm.val()).toBe(scope.codes[0].substr(0, 6));
       angular.element(elm[0]).triggerHandler('change');
       expect(sandboxEl.find('.dropdown-menu li').length).toBe(1); // 000000
+    });
+
+    it('should not use a comparator if one is not set', function () {
+      scope.comparator = '';
+
+      var elm = compileDirective('comparator');
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val(scope.codes[0].substr(0, 3)); // 001
+      expect(elm.val()).toBe(scope.codes[0].substr(0, 3));
+      angular.element(elm[0]).triggerHandler('change');
+      expect(sandboxEl.find('.dropdown-menu li').length).toBe(2); // 001000, 002001
+    });
+
+    it('should use the comparator if it is set', function () {
+      scope.startsWith = function (actual, expected) { return actual.indexOf(expected) === 0; };
+      scope.comparator = 'startsWith';
+
+      var elm = compileDirective('comparator');
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val(scope.codes[0].substr(0, 3)); // 001
+      expect(elm.val()).toBe(scope.codes[0].substr(0, 3));
+      angular.element(elm[0]).triggerHandler('change');
+      expect(sandboxEl.find('.dropdown-menu li').length).toBe(1); // Our comparator should only match the beginning - 001000
     });
 
     // @TODO

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -17,7 +17,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
       delay: 0,
       minLength: 1,
       filter: 'filter',
-      limit: 6
+      limit: 6,
+      comparator: ''
     };
 
     this.$get = function($window, $rootScope, $tooltip) {
@@ -172,15 +173,18 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'comparator'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
         // Build proper ngOptions
         var filter = options.filter || defaults.filter;
         var limit = options.limit || defaults.limit;
+        var comparator = options.comparator || defaults.comparator;
+
         var ngOptions = attr.ngOptions;
         if(filter) ngOptions += ' | ' + filter + ':$viewValue';
+        if (comparator) ngOptions += ':' + comparator;
         if(limit) ngOptions += ' | limitTo:' + limit;
         var parsedOptions = $parseOptions(ngOptions);
 


### PR DESCRIPTION
A comparator can be chained onto the filter in Angular.  This exposes the ability to add a comparator to the filter that controls what shows in the typeahead.
