### PR TITLE
docs(datepicker): remove duplicate class attribute

### DIFF
--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -43,10 +43,10 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
       <!-- Date range example -->
       <div class="form-group">
         <label class="control-label"><i class="fa fa-calendar"></i> <i class="fa fa-arrows-h"></i> <i class="fa fa-calendar"></i> Date range <small>(dynamic)</small></label><br>
-        <div class="form-group" class="col-xs-3">
+        <div class="form-group col-xs-6">
           <input type="text" class="form-control" ng-model="fromDate"  data-max-date="{{untilDate}}" placeholder="From" bs-datepicker>
         </div>
-        <div class="form-group" class="col-xs-3">
+        <div class="form-group col-xs-6">
           <input type="text" class="form-control" ng-model="untilDate"  data-min-date="{{fromDate}}" placeholder="Until" bs-datepicker>
         </div>
       </div>


### PR DESCRIPTION
The date range example was using two class attributes on the same element, which is flagged as an error in plunker. Had to increase the col size to prevent inputs clipping.
