### PR TITLE
fix(timepicker): update model value in angular 1.3

### DIFF
--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -171,6 +171,10 @@ describe('timepicker', function() {
       expect(scope.selectedTime.toISOString().substr(0, 10)).toBe('1970-01-01');
       angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(12)')).triggerHandler('click');
       expect(scope.selectedTime.toISOString().substr(0, 10)).toBe('1970-01-01');
+      angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(11)')).triggerHandler('click');
+      expect(elm.val()).toBe('11:30 AM');
+      expect(scope.selectedTime).toEqual(new Date(1970, 0, 1, 11, 30));
+      expect(scope.selectedTime.toISOString().substr(0, 10)).toBe('1970-01-01');
     });
 
     it('should correctly parse input time', function() {

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -86,7 +86,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           if(!angular.isDate(date)) date = new Date(date);
           if(index === 0) controller.$dateValue.setHours(date.getHours());
           else if(index === 1) controller.$dateValue.setMinutes(date.getMinutes());
-          controller.$setViewValue(controller.$dateValue);
+          controller.$setViewValue(angular.copy(controller.$dateValue));
           controller.$render();
           if(options.autoclose && !keep) {
             $timeout(function() { $timepicker.hide(true); });
@@ -99,7 +99,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           }
           var hours = (date || controller.$dateValue).getHours();
           controller.$dateValue.setHours(hours < 12 ? hours + 12 : hours - 12);
-          controller.$setViewValue(controller.$dateValue);
+          controller.$setViewValue(angular.copy(controller.$dateValue));
           controller.$render();
         };
 


### PR DESCRIPTION
In angular 1.3 the model value was only being updated the first time, because of changes in the change detection mechanism. AngularJS no longer compares the contents of the model value, so we need to pass a copy of the value to force change detection.

closes #1070 fixes #800 fixes #899 helps in #1154
