### PR TITLE
fix(tooltip): overwrite inherited title value in angular 1.3.1

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -466,6 +466,12 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
+        // overwrite inherited title value when no value specified
+        // fix for angular 1.3.1 531a8de72c439d8ddd064874bf364c00cedabb11
+        if (!scope.hasOwnProperty('title')){
+          scope.title = '';
+        }
+
         // Observe scope attributes for change
         attr.$observe('title', function(newValue) {
           if (angular.isDefined(newValue) || !scope.hasOwnProperty('title')) {


### PR DESCRIPTION
Angular 1.3.1 commit 531a8de72c439d8ddd064874bf364c00cedabb11 no longer calls the attribute $observe function if the attribute is not defined in the scope, so previous fix no longer works. Added direct check for title attribute is defined in scope to tooltip code.
