### PR TITLE
fix(dimensions) remove redundant offset calc

### DIFF
--- a/src/helpers/dimensions.js
+++ b/src/helpers/dimensions.js
@@ -73,7 +73,6 @@ angular.module('mgcrea.ngStrap.helpers.dimensions', [])
 
         // Get *real* offsetParentElement
         offsetParentElement = offsetParent(element);
-        offset = fn.offset(element);
 
         // Get correct offsets
         offset = fn.offset(element);


### PR DESCRIPTION
Removing what looks to be an extra call to calculate the element offset.
