### PR TITLE
fix(scrollspy): replace 'this' with '$scrollspy' in callbacks

### DIFF
--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -124,7 +124,9 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
         };
 
         $scrollspy.checkPositionWithEventLoop = function() {
-          setTimeout(this.checkPosition, 1);
+          // IE 9 throws an error if we use 'this' instead of '$scrollspy'
+          // in this setTimeout call
+          setTimeout($scrollspy.checkPosition, 1);
         };
 
         // Protected methods

--- a/src/scrollspy/test/scrollspy.spec.js
+++ b/src/scrollspy/test/scrollspy.spec.js
@@ -64,6 +64,13 @@ describe('affix', function () {
       expect(1).toBe(1);
     });
 
+    it('should not throw when clicking on scroll element', function() {
+      // IE 9 throws an error if we use 'this' instead of '$scrollspy'
+      // in the scroll element click handler
+      var elm = compileDirective('default');
+      expect(function() { angular.element(window).triggerHandler('click'); }).not.toThrow();
+    });
+
   });
 
 });


### PR DESCRIPTION
Using 'this' in callbacks causes errors in IE, so replaced them with explicit '$scrollspy' instance reference.

should fix #1229 
