### PR TITLE
fix(datepicker): initial value with ng-required attribute

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -361,14 +361,18 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
           //   date = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
           // }
           controller.$dateValue = date;
-          return controller.$dateValue;
+          return getDateFormattedString();
         });
 
         // viewValue -> element
         controller.$render = function() {
           // console.warn('$render("%s"): viewValue=%o', element.attr('ng-model'), controller.$viewValue);
-          element.val(!controller.$dateValue || isNaN(controller.$dateValue.getTime()) ? '' : dateFilter(controller.$dateValue, options.dateFormat));
+          element.val(getDateFormattedString());
         };
+
+        function getDateFormattedString() {
+          return !controller.$dateValue || isNaN(controller.$dateValue.getTime()) ? '' : dateFilter(controller.$dateValue, options.dateFormat);
+        }
 
         // Garbage collection
         scope.$on('$destroy', function() {

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -46,6 +46,10 @@ describe('datepicker', function() {
       scope: {selectedDate: new Date(1986, 1, 22), onChange: function() {}},
       element: '<input type="text" ng-model="selectedDate" ng-change="onChange()" bs-datepicker>'
     },
+    'markup-ngRequired': {
+      scope: {selectedDate: new Date(2010, 1, 22)},
+      element: '<input type="text" ng-model="selectedDate" ng-required="true" bs-datepicker>'
+    },
     'options-animation': {
       element: '<div class="btn" data-animation="am-flip-x" ng-model="datepickeredIcon" ng-options="icon.value as icon.label for icon in icons" bs-datepicker></div>'
     },
@@ -338,6 +342,19 @@ describe('datepicker', function() {
       var spy = spyOn(scope, 'onChange').and.callThrough();
       angular.element(sandboxEl.find('.dropdown-menu tbody .btn:eq(1)')[0]).triggerHandler('click');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should support ngRequired markup', function() {
+      var elm = compileDirective('markup-ngRequired');
+      var testDate = new Date(2010, 1, 22);
+
+      expect(elm.val()).not.toBe('');
+      expect(scope.selectedDate).toBeDefined();
+      expect(scope.selectedDate).toEqual(testDate);
+
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.dropdown-menu tbody td .btn-primary').text().trim() * 1).toBe(testDate.getDate());
+      expect(elm.val()).toBe((testDate.getMonth() + 1) + '/' + testDate.getDate() + '/' + (testDate.getFullYear() + '').substr(2));
     });
 
     // iit('should only build the datepicker once', function() {


### PR DESCRIPTION
When using ng-required attribute in datepicker element in Angular 1.3, the element was not passing validation because it was returning a date object from the $formatter. With the new 1.3 pipeline, the $formatter needs to return a string when using an input type="text" element.

Same fix as was done for timepicker (f65fe9ff79c5fa5a3055d4fac82bed1d3bf9f1ca)
