### PR TITLE
Removed bootstrap and angular-motion dependencies from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,17 +33,17 @@
     "CONTRIBUTING.md"
   ],
   "dependencies": {
-    "angular": "^1.2.21",
-    "bootstrap": "^3.2.0",
-    "angular-motion": "^0.3.3"
+    "angular": "^1.2.21"
   },
   "devDependencies": {
     "angular-animate": "^1.2.21",
     "angular-i18n": "^1.2.21",
     "angular-mocks": "^1.2.21",
+    "angular-motion": "^0.3.3"
     "angular-route": "^1.2.21",
     "angular-sanitize": "^1.2.21",
     "angular-scenario": "^1.2.21",
+    "bootstrap": "^3.2.0",
     "highlightjs": "^8.0.0",
     "jquery": "^2.1.1",
     "font-awesome": "^4.1.0",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "angular-animate": "^1.2.21",
     "angular-i18n": "^1.2.21",
     "angular-mocks": "^1.2.21",
-    "angular-motion": "^0.3.3"
+    "angular-motion": "^0.3.3",
     "angular-route": "^1.2.21",
     "angular-sanitize": "^1.2.21",
     "angular-scenario": "^1.2.21",


### PR DESCRIPTION
Per projects description, there are no external dependencies other than Bootstrap.css.
Yet currently anyone that installs angular-strap via bower is also forced to install angular-motion(optional) and bootstrap(which is less driven). Some people may want to skip angular motion and some people will want to use bootstrap-sass for their workflow.
This PR moves angular-motion and bootstrap to the devDependencies setting which still lets you use it for a development flow(and viewing docs), but also allows people to ignore these packages for production flow.

I confirmed that all the tests pass and gulp serve does serve the docs