### PR TITLE
fix($animate): update animate.enter() behaviour

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -121,13 +121,20 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
             return;
           }
-          var parent;
+          var parent, after;
           if(angular.isElement(options.container)) {
             parent = options.container;
+            after = options.container[0].lastChild;
           } else {
-            parent = options.container ? findElement(options.container) : null;
+            if (options.container) {
+              parent = findElement(options.container);
+              after = parent.lastChild;
+            } else {
+              parent = null;
+              after = options.element;
+            }
           }
-          var after = options.container ? null : options.element;
+
 
           // Fetch a cloned element linked from template
           modalElement = $modal.$element = modalLinker(scope, function(clonedElement, scope) {});

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -199,7 +199,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
           scope.$emit(options.prefixEvent + '.show.before', $tooltip);
           var parent = options.container ? tipContainer : null;
-          var after = options.container ? null : element;
+          var after = options.container ? tipContainer[0].lastChild : element;
 
           // Hide any existing tipElement
           if(tipElement) destroyTipElement();
@@ -243,8 +243,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           }
 
           if(options.autoClose) {
-            // use timeout to hookup the events to prevent 
-            // event bubbling from being processed imediately. 
+            // use timeout to hookup the events to prevent
+            // event bubbling from being processed imediately.
             $timeout(function() {
               // Stop propagation when clicking inside tooltip
               tipElement.on('click', function(event) {


### PR DESCRIPTION
In angular 1.3 $animate.enter() will now insert in the first position of the parent element when "after" is not specified. This change updates the tooltip and modal $animate.enter() calls to specify after as the last element of the parent. 

this is due to changes from: https://github.com/angular/angular.js/commit/1cb8584e8490ecdb1b410a8846c4478c6c2c0e53

this caused nested tooltips/modals to be inserted behind the old ones i.e when one modal opens another modal and neither has a container specified (or if they had the same container).
