### PR TITLE
fix($animate): update animate.enter() behaviour

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -121,13 +121,19 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
           if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
             return;
           }
-          var parent;
+          var parent, after;
           if(angular.isElement(options.container)) {
             parent = options.container;
+            after = options.container[0].lastChild ? angular.element(options.container[0].lastChild) : null;
           } else {
-            parent = options.container ? findElement(options.container) : null;
+            if (options.container) {
+              parent = findElement(options.container);
+              after = parent[0].lastChild ? angular.element(parent[0].lastChild) : null;
+            } else {
+              parent = null;
+              after = options.element;
+            }
           }
-          var after = options.container ? null : options.element;
 
           // Fetch a cloned element linked from template
           modalElement = $modal.$element = modalLinker(scope, function(clonedElement, scope) {});

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -198,8 +198,19 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           if (!options.bsEnabled) return;
 
           scope.$emit(options.prefixEvent + '.show.before', $tooltip);
-          var parent = options.container ? tipContainer : null;
-          var after = options.container ? null : element;
+          var parent, after;
+          if (options.container) {
+            parent = tipContainer;
+            if (tipContainer[0].lastChild) {
+              after = angular.element(tipContainer[0].lastChild);
+            } else {
+              after = null;
+            }
+          } else {
+            parent = null;
+            after = element;
+          }
+
 
           // Hide any existing tipElement
           if(tipElement) destroyTipElement();
@@ -243,8 +254,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           }
 
           if(options.autoClose) {
-            // use timeout to hookup the events to prevent 
-            // event bubbling from being processed imediately. 
+            // use timeout to hookup the events to prevent
+            // event bubbling from being processed imediately.
             $timeout(function() {
               // Stop propagation when clicking inside tooltip
               tipElement.on('click', function(event) {


### PR DESCRIPTION
In angular 1.3 $animate.enter() will now insert in the first position of the parent element when "after" is not specified. This change updates the tooltip and modal $animate.enter() calls to specify after as the last element of the parent.

this is due to changes from: angular/angular.js@1cb8584

this caused nested tooltips/modals to be inserted behind the old ones i.e when one modal opens another modal and neither has a container specified (or if they had the same container).
