### PR TITLE
feat(bsRadio): Added support for value being modified by ngValue directive

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -142,7 +142,11 @@ angular.module('mgcrea.ngStrap.button', [])
         var isInput = element[0].nodeName === 'INPUT';
         var activeElement = isInput ? element.parent() : element;
 
-        var value = constantValueRegExp.test(attr.value) ? scope.$eval(attr.value) : attr.value;
+        var value;
+        attr.$observe('value', function(v) {
+          value = constantValueRegExp.test(v) ? scope.$eval(v) : v;
+          controller.$render();
+        });
 
         // model -> view
         controller.$render = function () {

--- a/src/button/test/button.radio.spec.js
+++ b/src/button/test/button.radio.spec.js
@@ -49,6 +49,13 @@ describe('bs-radio', function () {
                '  <label class="btn"><input type="radio" ng-model="radio.value" value="{{ falseValue }}" bs-radio>No</label>' +
                '</div>'
     },
+    'radio-ng-value': {
+      scope: {trueValue: 'yes', falseValue: 'no'},
+      element: '<div class="btn-group">' +
+               '  <label class="btn"><input type="radio" ng-model="radio.value" ng-value="trueValue" bs-radio>Yes</label>' +
+               '  <label class="btn"><input type="radio" ng-model="radio.value" ng-value="falseValue" bs-radio>No</label>' +
+               '</div>'
+    },
     'radio-button-markup': {
       element: '<div class="btn-group">' +
                '  <button type="button" class="btn" ng-model="radio.value" value="left" bs-radio>Left</button>' +
@@ -148,6 +155,50 @@ describe('bs-radio', function () {
       // expect(firstChild.children('input').is(':checked')).toBeTruthy();
       expect(secondChild).not.toHaveClass('active');
       // expect(secondChild.children('input').is(':checked')).toBeFalsy();
+
+      // Change true value
+      scope.trueValue = 'completely different';
+      scope.$digest();
+      $$rAF.flush();
+
+      expect(firstChild).not.toHaveClass('active');
+      expect(secondChild).not.toHaveClass('active');
+
+      // Match radio value to new true value
+      scope.radio.value = scope.trueValue;
+      scope.$digest();
+      $$rAF.flush();
+
+      expect(firstChild).toHaveClass('active');
+      expect(secondChild).not.toHaveClass('active');
+    });
+
+    it('with ng-value interpolated values', function () {
+      var element = compileDirective('radio-ng-value', {radio: {value: 'no'}});
+      var firstChild = element.children().eq(0), secondChild = element.children().eq(1);
+      expect(firstChild).not.toHaveClass('active');
+      expect(secondChild).toHaveClass('active');
+      scope.radio.value = 'yes';
+      scope.$digest();
+      $$rAF.flush();
+      expect(firstChild).toHaveClass('active');
+      expect(secondChild).not.toHaveClass('active');
+
+      // Change true value
+      scope.trueValue = 'completely different';
+      scope.$digest();
+      $$rAF.flush();
+
+      expect(firstChild).not.toHaveClass('active');
+      expect(secondChild).not.toHaveClass('active');
+
+      // Match radio value to new true value
+      scope.radio.value = scope.trueValue;
+      scope.$digest();
+      $$rAF.flush();
+
+      expect(firstChild).toHaveClass('active');
+      expect(secondChild).not.toHaveClass('active');
     });
 
     // @info dropped direct support in 1.2+


### PR DESCRIPTION
Right now, usage of ngValue directive with bsRadio is not supported. This patch observes value attribute instead of evaluating it during linking, therefore reacts for its changes.

This is now supported:
`<input type="radio" bs-radio ng-model="test" ng-value="scopeValue"/>`