### PR TITLE
fix(datepicker): correctly change view month when last day of month is s...

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -136,7 +136,10 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
         $datepicker.$selectPane = function(value) {
           var steps = $picker.steps;
-          var targetDate = new Date(Date.UTC(viewDate.year + ((steps.year || 0) * value), viewDate.month + ((steps.month || 0) * value), viewDate.date + ((steps.day || 0) * value)));
+          // set targetDate to first day of month to avoid problems with
+          // date values rollover. This assumes the viewDate does not
+          // depend on the day of the month 
+          var targetDate = new Date(Date.UTC(viewDate.year + ((steps.year || 0) * value), viewDate.month + ((steps.month || 0) * value), 1));
           angular.extend(viewDate, {year: targetDate.getUTCFullYear(), month: targetDate.getUTCMonth(), date: targetDate.getUTCDate()});
           $datepicker.$build();
         };

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -232,6 +232,34 @@ describe('datepicker', function() {
       expect(elm.val()).toBe('2/22/86');
     });
 
+    it('should correctly change view month when selecting next month button', function() {
+      var elm = compileDirective('default');
+      // set date to last day of January
+      scope.selectedDate = new Date(2014, 0, 31);
+      scope.$digest();
+      angular.element(elm[0]).triggerHandler('focus');
+
+      for (var nextMonth = 1; nextMonth < 12; nextMonth++) {
+        // should show next month view when selecting next month button
+        angular.element(sandboxEl.find('.dropdown-menu thead button:eq(2)')[0]).triggerHandler('click');
+        expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(new Date(2014, nextMonth, 1), 'MMMM yyyy'));
+      }
+    });
+
+    it('should correctly change view month when selecting previous month button', function() {
+      var elm = compileDirective('default');
+      // set date to last day of December
+      scope.selectedDate = new Date(2014, 11, 31);
+      scope.$digest();
+      angular.element(elm[0]).triggerHandler('focus');
+
+      for (var previousMonth = 10; previousMonth > -1; previousMonth--) {
+        // should show previous month view when selecting previous month button
+        angular.element(sandboxEl.find('.dropdown-menu thead button:eq(0)')[0]).triggerHandler('click');
+        expect(sandboxEl.find('.dropdown-menu thead button:eq(1)').text()).toBe(dateFilter(new Date(2014, previousMonth, 1), 'MMMM yyyy'));
+      }
+    });
+
     it('should correctly navigate to upper month view', function() {
       var elm = compileDirective('default');
       var date = today.getDate(), month = today.getMonth();


### PR DESCRIPTION
...elected

When the selected date corresponds to a day that doesn't exist in the next/previous month, the month change would not work correctly - either it would skip a month forward or it would not change to the previous month. This was caused by javascript date values rollover when changing month part of date because months have a different number of days.
This fix uses the first day of the month in the calculations to avoid the rollover.

Fix for #1278 
