### PR TITLE
fix(select): multi-select checkmark icon displays correctly without addi...

### DIFF
--- a/src/select/select.tpl.html
+++ b/src/select/select.tpl.html
@@ -8,7 +8,7 @@
   <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive($index)}">
     <a style="cursor: default;" role="menuitem" tabindex="-1" ng-click="$select($index, $event)">
       <span ng-bind="match.label"></span>
+      <i class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive($index)"></i>
     </a>
-    <i style="cursor: default;" class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive($index)" ng-click="$select($index, $event)"></i>
   </li>
 </ul>

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -191,7 +191,7 @@ describe('select', function () {
         angular.element(elm[0]).triggerHandler('focus');
         expect(sandboxEl.find('.dropdown-menu li').length).toBe(scope.icons.length);
         expect(sandboxEl.find('.dropdown-menu li:eq(0)').text().trim()).toBe(scope.icons[0].label);
-        expect(sandboxEl.find('.dropdown-menu li > i').length).toBe(scope.selectedIcons.length);
+        expect(sandboxEl.find('.dropdown-menu li > a > i').length).toBe(scope.selectedIcons.length);
       });
 
       it('should select and deselect all items', function() {


### PR DESCRIPTION
...tional CSS

Reverts commit d167af80b5e055d8195559975216a1fde353230f and instead moves the checkmark icon element to before the label span. As the checkmark icon is "pull-right", it can be placed before the label.

Related to #1281.
