### PR TITLE
fix(select): multi-select checkmark icon displays correctly without addi...

### DIFF
--- a/src/select/select.tpl.html
+++ b/src/select/select.tpl.html
@@ -7,8 +7,8 @@
   </li>
   <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive($index)}">
     <a style="cursor: default;" role="menuitem" tabindex="-1" ng-click="$select($index, $event)">
-      <span ng-bind="match.label"></span>
       <i class="{{$iconCheckmark}} pull-right" ng-if="$isMultiple && $isActive($index)"></i>
+      <span ng-bind="match.label"></span>
     </a>
   </li>
 </ul>


### PR DESCRIPTION
...tional CSS

Reverts commit d167af80b5e055d8195559975216a1fde353230f and instead moves the checkmark icon element to before the label span. As the checkmark icon is "pull-right", it can be placed before the label.
