### PR TITLE
Remove opened datepicker cause error

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -226,6 +226,7 @@ angular.module('mgcrea.ngStrap.datepicker', ['mgcrea.ngStrap.helpers.dateParser'
         var _hide = $datepicker.hide;
         $datepicker.hide = function(blur) {
           if(!$datepicker.$isShown) return;
+          if($datepicker.$element === null) return;     // If element no more exist in DOM, return
           $datepicker.$element.off(isTouch ? 'touchstart' : 'mousedown', $datepicker.$onMouseDown);
           if(options.keyboard) {
             element.off('keydown', $datepicker.$onKeyDown);


### PR DESCRIPTION
When an auther component have removed an opened datepicker, we got error 'off undefined' because $element no more existe.

This error can appears in a ngGrid custom template.