### PR TITLE
prevent multiple loading of the same template.

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -27,6 +27,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
       var requestAnimationFrame = $window.requestAnimationFrame || $window.setTimeout;
       var bodyElement = angular.element($window.document.body);
       var htmlReplaceRegExp = /ng-bind="/ig;
+      var templates = {};
 
       function ModalFactory(config) {
 
@@ -259,7 +260,10 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
       }
 
       function fetchTemplate(template) {
-        return $q.when($templateCache.get(template) || $http.get(template))
+        if( templates[template] === undefined )
+          templates[template] = $q.when($templateCache.get(template) || $http.get(template));
+
+        return templates[template]
         .then(function(res) {
           if(angular.isObject(res)) {
             $templateCache.put(template, res.data);

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -31,6 +31,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
       var isTouch = 'createTouch' in $window.document;
       var htmlReplaceRegExp = /ng-bind="/ig;
       var $body = angular.element($window.document);
+      var templates = {};
 
       function TooltipFactory(element, config) {
 
@@ -519,7 +520,10 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
       }
 
       function fetchTemplate(template) {
-        return $q.when($templateCache.get(template) || $http.get(template))
+        if( templates[template] === undefined )
+          templates[template] = $q.when($templateCache.get(template) || $http.get(template));
+
+        return templates[template]
         .then(function(res) {
           if(angular.isObject(res)) {
             $templateCache.put(template, res.data);


### PR DESCRIPTION
The issue is that the same template was loaded as mush as the directive was used.

My assumption is that the templateCache service didn't had a chance to save the template from the first fetch so he keep sending http requests each time.

solution:
save array of the promises and just if the template key is not in the array, fetch it.
