### PR TITLE
fix(docs): add new date-formatter.js helper to docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,6 +107,7 @@
   <script src="helpers/debounce.js"></script>
   <script src="helpers/parse-options.js"></script>
   <script src="helpers/date-parser.js"></script>
+  <script src="helpers/date-formatter.js"></script>
   <script src="modal/modal.js"></script>
   <script src="aside/aside.js"></script>
   <script src="alert/alert.js"></script>


### PR DESCRIPTION
The new $dateFormatter helper service was missing from the docs index.html page.
