### PR TITLE
fix(affix): revert to $affix reference in $onResize event handler

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -129,8 +129,8 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
         };
 
         $affix.$onResize = function() {
-          this.$parseOffsets();
-          this.checkPosition();
+          $affix.$parseOffsets();
+          $affix.checkPosition();
         };
         $affix.$debouncedOnResize = debounce($affix.$onResize, 50);
 


### PR DESCRIPTION
The affix $onResize event handler was throwing an error when using 'this' to refer to $affix
