### PR TITLE
fix(datepicker): invalidate manual input value with non-existant day

### DIFF
--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -230,6 +230,26 @@ describe('datepicker', function() {
       expect(elm.val()).toBe((today.getMonth() + 1) + '/15/' + (today.getFullYear() + '').substr(2));
     });
 
+    it('should correctly set the model with manually typed value', function() {
+      var elm = compileDirective('default', { selectedDate: new Date(2014, 1, 10)});
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('11/30/14');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(scope.selectedDate).toEqual(new Date(2014, 10, 30));
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+    });
+
+    it('should invalidate input with non-existing manually typed value', function() {
+      var elm = compileDirective('default', { selectedDate: new Date(2014, 1, 10)});
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('02/31/14');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(scope.selectedDate).toBeUndefined();
+      expect(angular.element(elm[0]).hasClass('ng-invalid')).toBeTruthy();
+    });
+
     it('should correctly be cleared when model is cleared', function() {
       var elm = compileDirective('default');
       scope.selectedDate = null;

--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -4,7 +4,7 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
 
 .provider('$dateParser', function($localeProvider) {
 
-  // define a custom ParseDate object to use instead of native Date 
+  // define a custom ParseDate object to use instead of native Date
   // to avoid date values wrapping when setting date component values
   function ParseDate() {
     this.year = 1970;
@@ -53,7 +53,7 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
     for (var i=0; i<len; i++) {
       if (array[i].toLowerCase() === str) { return i; }
     }
-    return -1; // Return -1 per the "Array.indexOf()" method.    
+    return -1; // Return -1 per the "Array.indexOf()" method.
   }
 
   var defaults = this.defaults = {
@@ -144,7 +144,14 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
           formatSetMap[i] && formatSetMap[i].call(date, matches[i+1]);
         }
         // convert back to native Date object
-        return date.toDate();
+        var newDate = date.toDate();
+
+        // check new native Date object for day values overflow
+        if (parseInt(date.day, 10) !== newDate.getDate()) {
+          return false;
+        }
+
+        return newDate;
       };
 
       $dateParser.getDateForAttribute = function(key, value) {
@@ -177,7 +184,7 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
           time = new Date(parseInt(value, 10)).setFullYear(1970, 0, 1);
         } else if (angular.isString(value) && 0 === value.length) { // Reset time
           time = key === 'minTime' ? -Infinity : +Infinity;
-        } else { 
+        } else {
           time = $dateParser.parse(value, new Date(1970, 0, 1, 0));
         }
 

--- a/src/helpers/test/date-parser.spec.js
+++ b/src/helpers/test/date-parser.spec.js
@@ -294,6 +294,7 @@ describe('dateParser', function () {
           {val:'20/10/2014', expect: new Date(2014,9,20), reason:'4 digit year unambiguous day/month'},
           {val:'10/10/2014', expect: new Date(2014,9,10), reason:'4 digit year ambiguous day/month'},
           {val:'10/10/1814', expect: new Date(1814,9,10), reason:'4 digit year ambiguous day/month with different century'},
+          {val:'30/02/2014', expect: false, reason:'non-existing month day'},
         ]);
     });
 
@@ -308,6 +309,7 @@ describe('dateParser', function () {
         { val: '2014/08/31', baseVal: new Date(2014,1,25), expect: false },
         { val: '2014', baseVal: new Date(2014,1,25), expect: false },
         { val: 'Jan', baseVal: new Date(2014,1,25), expect: false },
+        { val: '31/09/2014', baseVal: new Date(2014,1,25), expect: false },
       ];
 
       beforeEach(function() {
@@ -333,6 +335,7 @@ describe('dateParser', function () {
         { val: '31/08/2014', baseVal: new Date(2014,1,25), expect: false },
         { val: '2014', baseVal: new Date(2014,1,25), expect: false },
         { val: 'Jan', baseVal: new Date(2014,1,25), expect: false },
+        { val: '2014/09/31', baseVal: new Date(2014,1,25), expect: false },
       ];
 
       beforeEach(function() {


### PR DESCRIPTION
Datepicker was accepting manually input values with non-existant days, like '31/02/2014', because the javascript Date object would overflow the day value and give back '03-03-2014'. This fix checks the parsed day to see if it matches the input day value, otherwise, it invalidates the input.

Fix for #816
