### PR TITLE
Typeahead refactor select mode and model update

### DIFF
--- a/src/typeahead/docs/typeahead.demo.html
+++ b/src/typeahead/docs/typeahead.demo.html
@@ -40,12 +40,18 @@ $scope.selectedAddress = "{{selectedAddress}}";
         <label><i class="fa fa-home"></i> Address <small>(async via maps.googleapis.com)</small></label>
         <input type="text" class="form-control" ng-model="selectedAddress" data-animation="am-flip-x" ng-options="address.formatted_address as address.formatted_address for address in getAddress($viewValue)" placeholder="Enter address" bs-typeahead>
       </div>
+      <hr>
+      <div class="form-group">
+        <label><i class="fa fa-globe"></i> State <small>(with selectMode="true")</small></label>
+        <input type="text" class="form-control" ng-model="selectedState" ng-options="state for state in states" placeholder="Enter state" data-select-mode="true" bs-typeahead>
+      </div>
+
     </form>
   </div>
 
 
   <h2 id="typeaheads-usage">Usage</h2>
-  <p>Append a <code>bs-typeahead</code>attribute to any element to enable the directive.</p>
+  <p>Append a <code>bs-typeahead</code>attribute to any element to enable the directive and use the <code>ngOptions</code> attribute to specify the available items.</p>
   <div class="callout callout-info">
     <h4>The module exposes a <code>$typeahead</code>service</h4>
     <p>Available for programmatic use (mainly in directives as it requires a DOM element).</p>
@@ -76,6 +82,19 @@ $scope.selectedAddress = "{{selectedAddress}}";
         </tr>
       </thead>
       <tbody>
+        <tr>
+          <td>ngOptions</td>
+          <td>string</td>
+          <td></td>
+          <td>
+            <p>A string using the AngularJS <a href="https://docs.angularjs.org/api/ng/directive/select" target="_blank">ngOptions</a> comprehension_expression format that specifies the available items.</p>
+            <p>Currently it only supports the following formats: 
+              <ul>
+                <li><code>label <b>for</b> value <b>in</b> array</code></li>
+                <li><code>select <b>as</b> label <b>for</b> value <b>in</b> array</code></li>
+              </ul>
+          </td>
+        </tr>
         <tr>
           <td>animation</td>
           <td>string</td>
@@ -154,6 +173,14 @@ $scope.selectedAddress = "{{selectedAddress}}";
           <td>''</td>
           <td>
             <p>The name of the comparator function which is used in determining a match.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>selectMode</td>
+          <td>bool</td>
+          <td>false</td>
+          <td>
+            <p>If you include this attribute, the typeahead will restrict user input to the parsed ngOptions.</p>
           </td>
         </tr>
       </tbody>

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -83,6 +83,9 @@ describe('typeahead', function () {
     },
     'options-keyboard': {
       element: '<input type="text" ng-model="selectedState" ng-options="state for state in states" data-keyboard="true" bs-typeahead>'
+    },
+    'options-selectMode': {
+      element: '<input type="text" ng-model="selectedState" data-select-mode="{{selectMode}}" ng-options="state for state in states" bs-typeahead>'
     }
   };
 
@@ -452,6 +455,106 @@ describe('typeahead', function () {
         expect(scope.selectedState).toBe('North Carolina');
       });
 
+    });
+
+  });
+
+  describe('selectMode', function() {
+
+    it('should not restrict when selectMode value is empty', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: ''});
+      elm.val('califon');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(elm.val()).toEqual('califon');
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+    });
+
+    it('should restrict user input when selectMode attribute is not empty', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: '-'});
+      elm.val('califo');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(elm.val()).toEqual('califo');
+      expect(scope.selectedState).toBeUndefined();
+
+      elm.val('califon');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(elm.val()).toEqual('califo');
+
+      elm.val('california');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(elm.val()).toEqual('california');
+    });
+
+    it('should only update ngModel when user selects from options list', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: '-', selectedState: undefined});
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('california');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(elm.val()).toEqual('california');
+      expect(scope.selectedState).toBeUndefined();
+
+      angular.element(sandboxEl.find('.dropdown-menu li:eq(0) a').get(0)).triggerHandler('click');
+      scope.$digest();
+      expect(elm.val()).toEqual('California');
+      expect(scope.selectedState).toEqual('California');
+    });
+
+    // Because we are setting ngModel to undefined,
+    //   - in Angular 1.3 the element will not have ng-valid class
+    //   - in Angular 1.2 the element will have ng-valid class
+    // this should be uniform for both versions, no???
+    it('should only set ng-valid class when user selects an option', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: '-', selectedState: undefined});
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('california');
+      angular.element(elm[0]).triggerHandler('change');
+      scope.$digest();
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeFalsy();
+
+      angular.element(sandboxEl.find('.dropdown-menu li:eq(0) a').get(0)).triggerHandler('click');
+      scope.$digest();
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+    });
+
+    // NEXT 2 TESTS ARE ALTERNATIVES:
+    // if user types something in input, should we set ngModel to undefined
+    // until user makes a selection from dropdown options?
+    // or should we keep current ngModel value unchanged?
+    it('should change ngModel to undefined when typing invalid input', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: '-'});
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('california');
+      angular.element(elm[0]).triggerHandler('change');
+      angular.element(sandboxEl.find('.dropdown-menu li:eq(0) a').get(0)).triggerHandler('click');
+      expect(elm.val()).toEqual('California');
+      expect(scope.selectedState).toEqual('California');
+
+      elm.val('Californiax');
+      angular.element(elm[0]).triggerHandler('change');
+      expect(elm.val()).toEqual('California');
+      expect(scope.selectedState).toBeUndefined();
+    });
+
+    xit('should not change ngModel when typing invalid input', function() {
+      var elm = compileDirective('options-selectMode', {selectMode: '-'});
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('california');
+      angular.element(elm[0]).triggerHandler('change');
+      angular.element(sandboxEl.find('.dropdown-menu li:eq(0) a').get(0)).triggerHandler('click');
+      expect(elm.val()).toEqual('California');
+      expect(scope.selectedState).toEqual('California');
+
+      elm.val('Californiax');
+      angular.element(elm[0]).triggerHandler('change');
+      expect(elm.val()).toEqual('California');
+      expect(scope.selectedState).toBeUndefined();
+      expect(scope.selectedState).toEqual('California');
     });
 
   });

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -52,7 +52,7 @@ describe('typeahead', function () {
     },
     'markup-objectValue-custom': {
       scope: {selectedIcon: {}, icons: [{val: 'gear', fr_FR: '<i class="fa fa-gear"></i> Gear'}, {val: 'globe', fr_FR: '<i class="fa fa-globe"></i> Globe'}, {val: 'heart', fr_FR: '<i class="fa fa-heart"></i> Heart'}, {val: 'camera', fr_FR: '<i class="fa fa-camera"></i> Camera'}]},
-      element: '<input type="text" class="form-control" ng-model="selectedIcon" data-html="1" ng-options="icon as icon[\'fr_FR\'] for icon in icons" bs-typeahead>'
+      element: '<input type="text" class="form-control" ng-model="selectedIcon" data-html="1" ng-options="icon as icon[\'fr_FR\'] for icon in icons"  data-min-length="0" bs-typeahead>'
     },
     'markup-renew-items': {
       scope: {selectedIcon: {}, icons: function(){return [{alt: 'Gear'}, {alt: 'Globe'}, {alt: 'Heart'}, {alt: 'Camera'}];}},

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -71,8 +71,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           return parsedOptions.valuesFn(scope, controller).then(function(matches){
             if(!matches.length){
               if(options.selectMode && _stringify(controller.$viewValue).length > 0){
-                  controller.$setViewValue(_lastViewValue);
-                  controller.$render();
+                controller.$setViewValue(_lastViewValue);
+                controller.$render();
               } else {
                 scope.$resetMatches();
               }
@@ -88,39 +88,38 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           });
         };
 
-
         $typeahead.setInput = function(inputValue){
 
-            if(typeof inputValue === 'object'){
-              // if argument is object then caller is the select callback and not the parser.
-              // set _selectingValue and call $setViewValue. No need to return value here.
-              _selectingValue = inputValue.value;
-              if(angular.version.minor > 2 && controller.$viewValue === inputValue.label){
-                controller.$validate();
-              } else {
-                controller.$setViewValue(inputValue.label);
-              }
+          if(typeof inputValue === 'object'){
+            // if argument is object then caller is the select callback and not the parser.
+            // set _selectingValue and call $setViewValue. No need to return value here.
+            _selectingValue = inputValue.value;
+            if(angular.version.minor > 2 && controller.$viewValue === inputValue.label){
+              controller.$validate();
+            } else {
+              controller.$setViewValue(inputValue.label);
+            }
+
+          } else {
+
+            if(_selectingValue !== null){
+              // viewValue set by selection.
+              scope.$modelValue = _selectingValue;
+              scope.$resetMatches();
+              controller.$render();
+
+              _selectingValue = null, _hasSelection = true, _lastViewValue = inputValue;
 
             } else {
 
-              if(_selectingValue !== null){
-                // viewValue set by selection.
-                scope.$modelValue = _selectingValue;
-                scope.$resetMatches();
-                controller.$render();
-
-                _selectingValue = null, _hasSelection = true, _lastViewValue = inputValue;
-
-              } else {
-
-                if(_stringify(inputValue).length >= options.minLength){
-                  $typeahead.updateMatches();
-                }
-                scope.$modelValue = !options.selectMode ? inputValue : undefined;
-                _hasSelection = false;
+              if(_stringify(inputValue).length >= options.minLength){
+                $typeahead.updateMatches();
               }
-              return scope.$modelValue;
+              scope.$modelValue = !options.selectMode ? inputValue : undefined;
+              _hasSelection = false;
             }
+            return scope.$modelValue;
+          }
         };
 
         $typeahead.setModel = function(value){
@@ -218,12 +217,11 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           var watchedOptions = parsedOptions.$match[7].replace(/\|.+/, '').replace(/\(.*\)/g, '').trim();
           scope.$watch(watchedOptions, function (newValue, oldValue) {
             if(newValue === oldValue) return;
-              $typeahead.updateMatches();
+            $typeahead.updateMatches();
           }, true);
         }
 
         return $typeahead;
-
       }
 
       TypeaheadFactory.defaults = defaults;
@@ -266,7 +264,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         };
 
         controller.$parsers.push(function (inputValue) {
-            return typeahead.setInput(inputValue);
+          return typeahead.setInput(inputValue);
         });
 
         controller.$formatters.push(function(modelValue){

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -262,9 +262,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         var typeahead = $typeahead(element, controller, options);
 
         typeahead.$scope.$select = function(item, index, evt) {
-          scope.$$postDigest(function() {
-            typeahead.setInput(item);
-          });
+          typeahead.setInput(item);
         };
 
         controller.$parsers.push(function (inputValue) {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -164,18 +164,20 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           if($typeahead.$isVisible()) {
             evt.preventDefault();
             evt.stopPropagation();
-          }
 
-          // Select with enter
-          if(evt.keyCode === 13 && scope.$matches.length) {
-            $typeahead.select(scope.$activeIndex);
-          }
+            // only process key press if suggestion list is visible
 
-          // Navigate with keyboard
-          else if(evt.keyCode === 38 && scope.$activeIndex > 0) scope.$activeIndex--;
-          else if(evt.keyCode === 40 && scope.$activeIndex < scope.$matches.length - 1) scope.$activeIndex++;
-          else if(angular.isUndefined(scope.$activeIndex)) scope.$activeIndex = 0;
-          scope.$digest();
+            // Select with enter
+            if(evt.keyCode === 13 && scope.$matches.length) {
+              $typeahead.setInput(scope.$matches[scope.$activeIndex]);
+            }
+
+            // Navigate with keyboard
+            else if(evt.keyCode === 38 && scope.$activeIndex > 0) scope.$activeIndex--;
+            else if(evt.keyCode === 40 && scope.$activeIndex < scope.$matches.length - 1) scope.$activeIndex++;
+            else if(angular.isUndefined(scope.$activeIndex)) scope.$activeIndex = 0;
+            scope.$digest();
+          }
         };
 
         // Overrides

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -21,7 +21,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
       comparator: ''
     };
 
-    this.$get = function($window, $rootScope, $tooltip, $timeout) {
+    this.$get = function($window, $rootScope, $tooltip, $parseOptions, $timeout) {
 
       var bodyEl = angular.element($window.document.body);
 
@@ -31,10 +31,16 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Common vars
         var options = angular.extend({}, defaults, config);
+        var parsedOptions = $parseOptions(config.ngOptions);
 
         $typeahead = $tooltip(element, options);
         var parentScope = config.scope;
         var scope = $typeahead.$scope;
+        var _selectingValue = null, _hasSelection = false, _firstShow = true, _isParsing = false, _lastViewValue;
+
+        function _stringify(val){
+          return val != null ? val : '';
+        }
 
         scope.$resetMatches = function(){
           scope.$matches = [];
@@ -48,38 +54,79 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           });
         };
 
-        scope.$select = function(index, evt) {
-          scope.$$postDigest(function() {
-            $typeahead.select(index);
-          });
-        };
-
         scope.$isVisible = function() {
           return $typeahead.$isVisible();
         };
 
         // Public methods
 
-        $typeahead.update = function(matches) {
-          scope.$matches = matches;
-          if(scope.$activeIndex >= matches.length) {
-            scope.$activeIndex = 0;
-          }
-        };
-
         $typeahead.activate = function(index) {
           scope.$activeIndex = index;
         };
 
-        $typeahead.select = function(index) {
-          var value = scope.$matches[index].value;
-          // console.log('$setViewValue', value);
-          controller.$setViewValue(value);
-          controller.$render();
-          scope.$resetMatches();
-          if(parentScope) parentScope.$digest();
-          // Emit event
-          scope.$emit(options.prefixEvent + '.select', value, index);
+        // updates matches managing invalid inputs in selectMode
+        $typeahead.updateMatches = function() {
+          _isParsing = true;
+          var copyOfViewValue = controller.$viewValue; // to prevent assigning _lastViewValue to a altered controller.$viewValue
+          return parsedOptions.valuesFn(scope, controller).then(function(matches){
+            if(!matches.length){
+              if(options.selectMode && _stringify(controller.$viewValue).length > 0){
+                  controller.$setViewValue(_lastViewValue);
+                  controller.$render();
+              } else {
+                scope.$resetMatches();
+              }
+            } else {
+              scope.$matches = matches;
+              if(scope.$activeIndex >= matches.length) {
+                scope.$activeIndex = 0;
+              }
+              _lastViewValue = copyOfViewValue;
+            }
+            _isParsing = false;
+            return scope.$matches;
+          });
+        };
+
+
+        $typeahead.setInput = function(inputValue){
+
+            if(typeof inputValue === 'object'){
+              // if argument is object then caller is the select callback and not the parser.
+              // set _selectingValue and call $setViewValue. No need to return value here.
+              _selectingValue = inputValue.value;
+              if(angular.version.minor > 2 && controller.$viewValue === inputValue.label){
+                controller.$validate();
+              } else {
+                controller.$setViewValue(inputValue.label);
+              }
+
+            } else {
+
+              if(_selectingValue !== null){
+                // viewValue set by selection.
+                scope.$modelValue = _selectingValue;
+                scope.$resetMatches();
+                controller.$render();
+
+                _selectingValue = null, _hasSelection = true, _lastViewValue = inputValue;
+
+              } else {
+
+                if(_stringify(inputValue).length >= options.minLength){
+                  $typeahead.updateMatches();
+                }
+                scope.$modelValue = !options.selectMode ? inputValue : undefined;
+                _hasSelection = false;
+              }
+              return scope.$modelValue;
+            }
+        };
+
+        $typeahead.setModel = function(value){
+          if(value != null) _hasSelection = true;
+          scope.$modelValue = value;
+          return parsedOptions.displayValue(value);
         };
 
         // Protected methods
@@ -89,7 +136,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
             return !!scope.$matches.length;
           }
           // minLength support
-          return scope.$matches.length && angular.isString(controller.$viewValue) && controller.$viewValue.length >= options.minLength;
+          // we need to stringify in angular < 1.3
+          return scope.$matches.length && _stringify(controller.$viewValue).length >= options.minLength && !_hasSelection;
         };
 
         $typeahead.$getIndex = function(value) {
@@ -109,6 +157,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         };
 
         $typeahead.$onKeyDown = function(evt) {
+          if(_isParsing) return false;
           if(!/(38|40|13)/.test(evt.keyCode)) return;
 
           // Let ngSubmit pass if the typeahead tip is hidden
@@ -133,6 +182,14 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         var show = $typeahead.show;
         $typeahead.show = function() {
+          // Initial call parsedOptions. Next calls are done in parser
+          // TODO update test to be able to use this condition
+          // if(_firstShow && _stringify(controller.$viewValue).length >= options.minLength && !_hasSelection){
+          if(_firstShow){
+            $typeahead.updateMatches();
+            _firstShow = false;
+          }
+
           show();
           // use timeout to hookup the events to prevent
           // event bubbling from being processed imediately.
@@ -146,12 +203,22 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         var hide = $typeahead.hide;
         $typeahead.hide = function() {
-          $typeahead.$element.off('mousedown', $typeahead.$onMouseDown);
+          $typeahead.$element && $typeahead.$element.off('mousedown', $typeahead.$onMouseDown);
           if(options.keyboard) {
             element.off('keydown', $typeahead.$onKeyDown);
           }
           hide();
         };
+
+        // Watch options on demand
+        if(options.watchOptions) {
+          // Watch ngOptions values before filtering for changes, drop function calls
+          var watchedOptions = parsedOptions.$match[7].replace(/\|.+/, '').replace(/\(.*\)/g, '').trim();
+          scope.$watch(watchedOptions, function (newValue, oldValue) {
+            if(newValue === oldValue) return;
+              $typeahead.updateMatches();
+          }, true);
+        }
 
         return $typeahead;
 
@@ -164,7 +231,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
   })
 
-  .directive('bsTypeahead', function($window, $parse, $q, $typeahead, $parseOptions) {
+  .directive('bsTypeahead', function($window, $q, $typeahead) {
 
     var defaults = $typeahead.defaults;
 
@@ -175,7 +242,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'comparator'], function(key) {
+        angular.forEach(['ngOptions', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'comparator'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
@@ -184,66 +251,37 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         var limit = options.limit || defaults.limit;
         var comparator = options.comparator || defaults.comparator;
 
-        var ngOptions = attr.ngOptions;
-        if(filter) ngOptions += ' | ' + filter + ':$viewValue';
-        if (comparator) ngOptions += ':' + comparator;
-        if(limit) ngOptions += ' | limitTo:' + limit;
-        var parsedOptions = $parseOptions(ngOptions);
+        if(filter) options.ngOptions += ' | ' + filter + ':$viewValue';
+        if(comparator) options.ngOptions += ':' + comparator;
+        if(limit) options.ngOptions += ' | limitTo:' + limit;
+
 
         // Initialize typeahead
         var typeahead = $typeahead(element, controller, options);
 
-        // Watch options on demand
-        if(options.watchOptions) {
-          // Watch ngOptions values before filtering for changes, drop function calls
-          var watchedOptions = parsedOptions.$match[7].replace(/\|.+/, '').replace(/\(.*\)/g, '').trim();
-          scope.$watch(watchedOptions, function (newValue, oldValue) {
-            // console.warn('scope.$watch(%s)', watchedOptions, newValue, oldValue);
-            parsedOptions.valuesFn(scope, controller).then(function (values) {
-              typeahead.update(values);
-              controller.$render();
-            });
-          }, true);
-        }
-
-        // Watch model for changes
-        scope.$watch(attr.ngModel, function(newValue, oldValue) {
-          // console.warn('$watch', element.attr('ng-model'), newValue);
-          scope.$modelValue = newValue; // Publish modelValue on scope for custom templates
-          parsedOptions.valuesFn(scope, controller)
-          .then(function(values) {
-            // Prevent input with no future prospect if selectMode is truthy
-            // @TODO test selectMode
-            if(options.selectMode && !values.length && newValue.length > 0) {
-              controller.$setViewValue(controller.$viewValue.substring(0, controller.$viewValue.length - 1));
-              return;
-            }
-            if(values.length > limit) values = values.slice(0, limit);
-            var isVisible = typeahead.$isVisible();
-            isVisible && typeahead.update(values);
-            // Do not re-queue an update if a correct value has been selected
-            if(values.length === 1 && values[0].value === newValue) return;
-            !isVisible && typeahead.update(values);
-            // Queue a new rendering that will leverage collection loading
-            controller.$render();
+        typeahead.$scope.$select = function(item, index, evt) {
+          scope.$$postDigest(function() {
+            typeahead.setInput(item);
           });
+        };
+
+        controller.$parsers.push(function (inputValue) {
+            return typeahead.setInput(inputValue);
         });
 
-        // modelValue -> $formatters -> viewValue
-        controller.$formatters.push(function(modelValue) {
-          // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
-          var displayValue = parsedOptions.displayValue(modelValue);
-          return displayValue === undefined ? '' : displayValue;
+        controller.$formatters.push(function(modelValue){
+          return typeahead.setModel(modelValue);
         });
+
 
         // Model rendering in view
         controller.$render = function () {
           // console.warn('$render', element.attr('ng-model'), 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue, 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
-          if(controller.$isEmpty(controller.$viewValue)) return element.val('');
-          var index = typeahead.$getIndex(controller.$modelValue);
-          var selected = angular.isDefined(index) ? typeahead.$scope.$matches[index].label : controller.$viewValue;
-          selected = angular.isObject(selected) ? parsedOptions.displayValue(selected) : selected;
-          element.val(selected ? selected.toString().replace(/<(?:.|\n)*?>/gm, '').trim() : '');
+          if(controller.$isEmpty(controller.$viewValue)) {
+            element.val('');
+          } else {
+            element.val(controller.$viewValue.toString().replace(/<(?:.|\n)*?>/gm, '').trim());
+          }
         };
 
         // Garbage collection

--- a/src/typeahead/typeahead.tpl.html
+++ b/src/typeahead/typeahead.tpl.html
@@ -1,5 +1,5 @@
 <ul tabindex="-1" class="typeahead dropdown-menu" ng-show="$isVisible()" role="select">
   <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $index == $activeIndex}">
-    <a role="menuitem" tabindex="-1" ng-click="$select($index, $event)" ng-bind="match.label"></a>
+    <a role="menuitem" tabindex="-1" ng-click="$select(match, $index, $event)" ng-bind="match.label"></a>
   </li>
 </ul>


### PR DESCRIPTION
Added some more tests and fixes on top of @ruifortes PR #1310, but still have some problems when testing in docs pages:
- Selecting item with ENTER key doesn't update ngModel bindings
- Icon input (minLength = 0) doesn't show options dropdown until you type something, then it will behave as expected
- In Firefox, when selecting an icon with the mouse the ngModel will be set to the item, but then pressing tab or clicking outside, the ngModel will be updated again with the input text (there were already some previous issue reports related to this: #652, #1011)
- In Angular 1.2, when using selectMode, the input will be ng-valid even when a value has not been selected (ngModel = undefined), causing 1 test to fail.

This is weird because the tests will pass, but it clearly show the problems using the docs pages. Except for the last one, I wasn't able to make the tests fail to reproduce these issues. Need help to fix them :(
