### PR TITLE
Fix(scrollSpy) destroy scroll event handler

### DIFF
--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -88,7 +88,7 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
           // Unbind events
           scrollEl.off('click', this.checkPositionWithEventLoop);
           windowEl.off('resize', debouncedCheckPosition);
-          scrollEl.off('scroll', debouncedCheckPosition);
+          scrollEl.off('scroll', throttledCheckPosition);
           unbindViewContentLoaded();
           unbindIncludeContentLoaded();
           if (scrollId) {


### PR DESCRIPTION
On destroy function, the unbinded event handler for scroll event was not the right one.
That produced memory leaks.
