### PR TITLE
fixed closing on click on button children (e.g. caret)

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -60,8 +60,8 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
         var show = $dropdown.show;
         $dropdown.show = function() {
           show();
-          // use timeout to hookup the events to prevent 
-          // event bubbling from being processed imediately. 
+          // use timeout to hookup the events to prevent
+          // event bubbling from being processed imediately.
           $timeout(function() {
             options.keyboard && $dropdown.$element.on('keydown', $dropdown.$onKeyDown);
             bodyEl.on('click', onBodyClick);
@@ -87,7 +87,7 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
         // Private functions
 
         function onBodyClick(evt) {
-          if(evt.target === element[0]) return;
+          if(evt.target === element[0] || evt.target.parentNode === element[0]) return;
           return evt.target !== element[0] && $dropdown.hide();
         }
 


### PR DESCRIPTION
The problem is that you can't add child elements to dropdown button. Because dropdown closes immediately after opening if you click on child element (e.g. on caret).
