### PR TITLE
fix(modal): Allow modal element to be available in before event

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -117,10 +117,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         $modal.show = function() {
           if(scope.$isShown) return;
-
-          if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
-            return;
-          }
+          
           var parent, after;
           if(angular.isElement(options.container)) {
             parent = options.container;
@@ -137,6 +134,10 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
           // Fetch a cloned element linked from template
           modalElement = $modal.$element = modalLinker(scope, function(clonedElement, scope) {});
+
+          if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
+            return;
+          }
 
           // Set the initial positioning.
           modalElement.css({display: 'block'}).addClass(options.placement);


### PR DESCRIPTION
Moved the modal.show.before event to occur immediately after the element is created.

I'm not sure if there is anything bad that could happen from this, but I wanted to be able to use the before event to place the modal over the button that triggered the modal.

Tests failed but that seemed to be something unrelated to do with the timePicker.