### PR TITLE
feat(select): allow select all/none button labels to be changed

### DIFF
--- a/src/select/docs/select.demo.html
+++ b/src/select/docs/select.demo.html
@@ -139,6 +139,22 @@ $scope.icons = "{{icons}}";
           </td>
         </tr>
         <tr>
+          <td>allText</td>
+          <td>string</td>
+          <td>'All'</td>
+          <td>
+            <p>Sets the text for the select all button.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>noneText</td>
+          <td>string</td>
+          <td>'None'</td>
+          <td>
+            <p>Sets the text for the select none button.</p>
+          </td>
+        </tr>
+        <tr>
           <td>max-length</td>
           <td>number</td>
           <td>3</td>

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -20,6 +20,8 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
       sort: true,
       caretHtml: '&nbsp;<span class="caret"></span>',
       placeholder: 'Choose among the following...',
+      allText: 'All',
+      noneText: 'None',
       maxLength: 3,
       maxLengthHtml: 'selected',
       iconCheckmark: 'glyphicon glyphicon-ok'
@@ -46,6 +48,8 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         scope.$isMultiple = options.multiple;
         scope.$showAllNoneButtons = options.allNoneButtons && options.multiple;
         scope.$iconCheckmark = options.iconCheckmark;
+        scope.$allText = options.allText;
+        scope.$noneText = options.noneText;
 
         scope.$activate = function(index) {
           scope.$$postDigest(function() {
@@ -238,7 +242,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'multiple', 'allNoneButtons', 'maxLength', 'maxLengthHtml'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'multiple', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/select/select.tpl.html
+++ b/src/select/select.tpl.html
@@ -1,8 +1,8 @@
 <ul tabindex="-1" class="select dropdown-menu" ng-show="$isVisible()" role="select">
   <li ng-if="$showAllNoneButtons">
     <div class="btn-group" style="margin-bottom: 5px; margin-left: 5px">
-      <button class="btn btn-default btn-xs" ng-click="$selectAll()">All</button>
-      <button class="btn btn-default btn-xs" ng-click="$selectNone()">None</button>
+      <button class="btn btn-default btn-xs" ng-click="$selectAll()">{{$allText}}</button>
+      <button class="btn btn-default btn-xs" ng-click="$selectNone()">{{$noneText}}</button>
     </div>
   </li>
   <li role="presentation" ng-repeat="match in $matches" ng-class="{active: $isActive($index)}">

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -49,6 +49,10 @@ describe('select', function () {
       scope: {selectedIcons: ['Globe'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
       element: '<button type="button" class="btn" data-multiple="1" all-none-buttons="1" ng-model="selectedIcons" ng-options="icon.value as icon.label for icon in icons" bs-select></button>'
     },
+    'options-multiple-all-none-buttons-text': {
+      scope: {allText: 'select all', noneText: 'select none', selectedIcons: ['Globe'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
+      element: '<button type="button" class="btn" data-multiple="1" all-none-buttons="1" data-all-text="{{allText}}" data-none-text="{{noneText}}" ng-model="selectedIcons" ng-options="icon.value as icon.label for icon in icons" bs-select></button>'
+    },
     'options-multiple-required': {
       scope: {selectedIcons: ['Globe'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
       element: '<button type="button" class="btn" data-multiple="1" ng-model="selectedIcons" ng-options="icon.value as icon.label for icon in icons" required bs-select></button>'
@@ -217,6 +221,23 @@ describe('select', function () {
         angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
         expect(elm.hasClass('ng-invalid-required')).toBe(true);
       });
+
+      it('should show default all/none button labels', function() {
+        var elm = compileDirective('options-multiple-all-none-buttons');
+        angular.element(elm[0]).triggerHandler('focus');
+
+        expect(sandboxEl.find('.dropdown-menu li > div > button:eq(0)').text()).toBe('All');
+        expect(sandboxEl.find('.dropdown-menu li > div > button:eq(1)').text()).toBe('None');
+      });
+
+      it('should support custom all/none button labels', function() {
+        var elm = compileDirective('options-multiple-all-none-buttons-text');
+        angular.element(elm[0]).triggerHandler('focus');
+
+        expect(sandboxEl.find('.dropdown-menu li > div > button:eq(0)').text()).toBe('select all');
+        expect(sandboxEl.find('.dropdown-menu li > div > button:eq(1)').text()).toBe('select none');
+      });
+
     });
 
     describe('maxLength', function () {


### PR DESCRIPTION
This provides 2 new options, 'allText' and 'noneText', that allow setting the text to display on the corresponding buttons. These options can be set by changing the provider defaults or by using data attributes on the select element.

Fixes #1364
