### PR TITLE
Update select.js to parse iconCheckmark option

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -242,7 +242,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'multiple', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'multiple', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
It was not into the options array of keys to parse. It would be nice to implement a test into the demos.