### PR TITLE
#1108 Workaround

### DIFF
--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -108,8 +108,16 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
           viewportHeight = Math.max($window.innerHeight, docEl.prop('clientHeight'));
 
           // Activate first element if scroll is smaller
-          if(scrollTop < sortedElements[0].offsetTop && activeTarget !== sortedElements[0].target) {
-            return $scrollspy.$activateElement(sortedElements[0]);
+          var firstElementInDom;
+          var index = 0;
+          while(angular.isUndefined(firstElementInDom) && index < sortedElements.length){
+            if(sortedElements[index].source[0].parentNode !==null){
+              firstElementInDom = sortedElements[index];
+            }
+             index++;
+          }
+          if(firstElementInDom && scrollTop < firstElementInDom.offsetTop && activeTarget !== firstElementInDom.target) {
+              return $scrollspy.$activateElement(firstElementInDom);
           }
 
           // Activate proper element

--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -118,6 +118,7 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
             if(activeTarget === sortedElements[i].target) continue;
             if(scrollTop < sortedElements[i].offsetTop) continue;
             if(sortedElements[i + 1] && scrollTop > sortedElements[i + 1].offsetTop) continue;
+            if (sortedElements[i].source[0].parentNode === null) continue;
             return $scrollspy.$activateElement(sortedElements[i]);
           }
 


### PR DESCRIPTION
#1108 Workaround

This avoids to get exceptions "Uncaught TypeError: Cannot read property 'nodeName' of undefined"
This happens when a scrollspy-ed element is removed from the DOM using ng-if.

According to scrollspy reported issues, it would be better to deal with dynamic contents (element removed or resized) but it seem's me to be really impacting changes.

This correction fix at least the side effect.
