### PR TITLE
feat(datepicker,timepicker): add timezone option

### DIFF
--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -97,6 +97,9 @@ describe('datepicker', function() {
       scope: {selectedDate: new Date(1986, 1, 22)},
       element: '<input type="text" ng-model="selectedDate" data-date-format="EEEE MMMM d, yyyy" bs-datepicker>'
     },
+    'options-timezone-utc': {
+      element: '<input type="text" ng-model="selectedDate" data-date-format="yyyy-MM-dd" data-timezone="UTC" bs-datepicker>'
+    },
     'options-strictFormat': {
       scope: {selectedDate: new Date(1986, 1, 4)},
       element: '<input type="text" ng-model="selectedDate" data-date-format="yyyy-M-d" data-strict-format="1" bs-datepicker>'
@@ -894,6 +897,36 @@ describe('datepicker', function() {
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(24)')).triggerHandler('click');
         expect(elm.val()).toBe('Feb 24, 1986');
       });
+
+    });
+
+    describe('timezone', function () {
+      var elm, i = 0;
+      var dates = [
+        new Date(2014, 0, 1),
+        new Date(2015, 0, 1),
+        new Date(2014, 11, 31),
+        new Date(2015, 11, 31),
+        new Date(2014, 7, 1),
+        new Date(2015, 7, 1),
+        new Date(1985, 0, 11)
+      ];
+
+      beforeEach(function() {
+        elm = compileDirective('options-timezone-utc', {selectedDate: dates[i]});
+      });
+
+      afterEach(function() { i++ });
+
+      for (var t = 0; t < dates.length; t++) {
+        it('should select date in utc timezone', function () {
+          expect(elm.val()).toBe(dateFilter(dates[i], 'yyyy-MM-dd', 'UTC'));
+          expect(scope.selectedDate.toDateString()).toBe(dates[i].toDateString());
+          angular.element(elm[0]).triggerHandler('focus');
+          angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(15)')).triggerHandler('click');
+          expect(elm.val()).toBe(dateFilter(dates[i], 'yyyy-MM-\'15\'', 'UTC'));
+        });
+      }
 
     });
 

--- a/src/helpers/date-formatter.js
+++ b/src/helpers/date-formatter.js
@@ -47,8 +47,8 @@ angular.module('mgcrea.ngStrap.helpers.dateFormatter', [])
       return !!splitTimeFormat(timeFormat)[3];
     };
 
-    this.formatDate = function(date, format, lang){
-      return dateFilter(date, format);
+    this.formatDate = function(date, format, lang, timezone){
+      return dateFilter(date, format, timezone);
     };
 
   });

--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -130,10 +130,10 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
         return regex.test(date);
       };
 
-      $dateParser.parse = function(value, baseDate, format) {
+      $dateParser.parse = function(value, baseDate, format, timezone) {
         // check for date format special names
         if(format) format = $locale.DATETIME_FORMATS[format] || format;
-        if(angular.isDate(value)) value = dateFilter(value, format || $dateParser.$format);
+        if(angular.isDate(value)) value = dateFilter(value, format || $dateParser.$format, timezone);
         var formatRegex = format ? regExpForFormat(format) : regex;
         var formatSetMap = format ? setMapForFormat(format) : setMap;
         var matches = formatRegex.exec(value);
@@ -205,6 +205,24 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
           return null;
         }
         date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
+        return date;
+      };
+
+      /* Correct the date for timezone offset.
+      * @param  date  (Date) the date to adjust
+      * @param  timezone  (string) the timezone to adjust for
+      * @param  undo  (boolean) to add or subtract timezone offset
+      * @return  (Date) the corrected date
+      */
+      $dateParser.timezoneOffsetAdjust = function(date, timezone, undo) {
+        if (!date) {
+          return null;
+        }
+        // Right now, only 'UTC' is supported.
+        if (timezone && timezone === 'UTC') {
+          date = new Date(date.getTime());
+          date.setMinutes(date.getMinutes() + (undo?-1:1)*date.getTimezoneOffset());
+        }
         return date;
       };
 

--- a/src/helpers/test/date-formatter.spec.js
+++ b/src/helpers/test/date-formatter.spec.js
@@ -68,9 +68,9 @@ describe('dateUtil', function () {
 
   describe('formatDate', function() {
     it('should call formatDate with only the date and format arguments', function() {
-      $dateFormatter.formatDate('date', 'format', 'lang');
+      $dateFormatter.formatDate('date', 'format', 'lang', 'timezone');
       expect(dateFilter.calls.count()).toBe(1);
-      expect(dateFilter.calls.argsFor(0)).toEqual([ 'date', 'format' ]);
+      expect(dateFilter.calls.argsFor(0)).toEqual([ 'date', 'format', 'timezone' ]);
     });
   });
 

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -71,6 +71,9 @@ describe('timepicker', function() {
       scope: {selectedTime: new Date(1970, 0, 1, 10, 30)},
       element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm" bs-timepicker>'
     },
+    'options-timezone-utc': {
+      element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm" data-timezone="UTC" bs-timepicker>'
+    },
     'options-timeType-string': {
       scope: {selectedTime: '10:30'},
       element: '<input type="text" ng-model="selectedTime" data-time-type="string" data-time-format="HH:mm" bs-timepicker>'
@@ -695,6 +698,33 @@ describe('timepicker', function() {
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(09)')).triggerHandler('click');
         expect(elm.val()).toBe('09:30');
       });
+
+    });
+
+    describe('timezone', function () {
+      var elm, i = 0;
+      var times = [
+        new Date(2014, 0, 1, 0, 0),
+        new Date(2015, 0, 1, 5, 0),
+        new Date(2014, 11, 31, 0, 0),
+        new Date(2015, 11, 31, 23, 0),
+        new Date(2014, 7, 1, 15, 30),
+        new Date(2015, 7, 1, 3, 15),
+        new Date(1985, 0, 11, 0, 0)
+      ];
+
+      beforeEach(function() {
+        elm = compileDirective('options-timezone-utc', {selectedTime: times[i]});
+      });
+
+      afterEach(function() { i++ });
+
+      for (var t = 0; t < times.length; t++) {
+        it('should render time in utc timezone', function () {
+          expect(elm.val()).toBe(dateFilter(times[i], 'HH:mm', 'UTC'));
+          expect(scope.selectedTime.toDateString()).toBe(times[i].toDateString());
+        });
+      }
 
     });
 


### PR DESCRIPTION
Since Angular's [dateFilter](https://docs.angularjs.org/api/ng/filter/date) already supports UTC timezone. This was a quick solution. I'm not sure if this is the right approach, but it can be extended to support all timezones and it worked for me.

```javascript
angular.extend($datepickerProvider.defaults, {
    dateFormat: 'dd/MM/yyyy',
    startWeek: 1,
    timezone: 'UTC'
});

angular.extend($timepickerProvider.defaults, {
    arrowBehavior: 'picker',
    timeFormat: 'HH:mm',
    length: 1,
    timezone: 'UTC'
});
```

Issues: [#885](https://github.com/mgcrea/angular-strap/issues/885), [#1100](https://github.com/mgcrea/angular-strap/issues/1100)