### PR TITLE
docs(popover): use 'manual' trigger in popover service example

### DIFF
--- a/src/popover/docs/popover.demo.html
+++ b/src/popover/docs/popover.demo.html
@@ -51,7 +51,7 @@
     <div class="highlight">
       <pre>
         <code class="javascript" highlight-block>
-          var myPopover = $popover(element, {title: 'My Title', content: 'My Content'});
+          var myPopover = $popover(element, {title: 'My Title', content: 'My Content', trigger: 'manual'});
         </code>
       </pre>
     </div>


### PR DESCRIPTION
Popover uses 'click' trigger by default and when using the service to show the popover as a result of clicking the associated element, it would cause the popover to toggle and hide immediately.

Closes #1453