### PR TITLE
added main so that jspm knows what to include

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "angular",
     "bootstrap"
   ],
+  "main": "dist/angular-strap.js",
   "homepage": "http://mgcrea.github.io/angular-strap",
   "bugs": "https://github.com/mgcrea/angular-strap/issues",
   "author": {


### PR DESCRIPTION
now you can simply require('angular-strap'), because jspm is expecting this on every package