### PR TITLE
feat(tooltip): Add support for Bootstrap's viewport positioning

### DIFF
--- a/docs/popover-viewport.html
+++ b/docs/popover-viewport.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en" ng-app="viewport">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Popover Viewport Example</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+  
+  <link href="bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
+
+  <link rel="stylesheet" href="bower_components/highlightjs/styles/github.css">
+  <link rel="stylesheet" href="bower_components/angular-motion/dist/angular-motion.css">
+  <link rel="stylesheet" href="bower_components/bootstrap-additions/dist/bootstrap-additions.css">
+
+  <style>
+    body {
+      height: 1200px;
+    }
+    .popover {
+      min-width: 250px;
+      max-width: 500px;
+    }
+    .popover .popover-content {
+      min-width: 250px;
+      max-width: 500px;
+      min-height: 100px;
+      text-align: left;
+    }
+    .container-viewport {
+      position: absolute;
+      top: 100px;
+      right: 250px;
+      left: 250px;
+      height: 300px;
+      background-color: #eee;
+    }
+    .btn-bottom-left {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+    
+    .btn-bottom-right {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+    }
+  </style>
+   
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-sanitize.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-animate.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-route.min.js"></script>
+
+  <script src="scripts/angular-strap.tpl.js"></script>
+  
+  <script src="module.js"></script>
+  <script src="helpers/raf.js"></script>
+  <script src="helpers/dimensions.js"></script>
+  <script src="helpers/debounce.js"></script>
+  <script src="helpers/parse-options.js"></script>
+  <script src="helpers/date-parser.js"></script>
+  <script src="modal/modal.js"></script>
+  <script src="aside/aside.js"></script>
+  <script src="alert/alert.js"></script>
+  <script src="button/button.js"></script>
+  <script src="select/select.js"></script>
+  <script src="datepicker/datepicker.js"></script>
+  <script src="timepicker/timepicker.js"></script>
+  <script src="navbar/navbar.js"></script>
+  <script src="tooltip/tooltip.js"></script>
+  <script src="popover/popover.js"></script>
+  <script src="dropdown/dropdown.js"></script>
+  <script src="typeahead/typeahead.js"></script>
+  <script src="scrollspy/scrollspy.js"></script>
+  <script src="affix/affix.js"></script>
+  <script src="tab/tab.js"></script>
+  <script src="collapse/collapse.js"></script>
+   
+  <script>
+    angular.module('viewport', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStrap.popover', 'ngAnimate']);
+  </script>
+</head>
+<body>
+    <button type="button" class="btn btn-default pull-right" bs-popover data-title="This should be shifted to the left" data-placement="bottom" data-trigger="hover">Shift Left</button>
+    <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted to the right" data-placement="bottom" data-trigger="hover">Shift Right</button>
+    <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted down" data-placement="right" data-trigger="hover">Shift Down</button>
+    <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted down" data-placement="right" data-animation="am-flip-x" data-trigger="hover">Shift Down w/ Animation</button>
+    <button type="button" class="btn btn-default" bs-popover data-title="This should not be shifted down" data-placement="right" data-viewport="null" data-trigger="hover">Don't Shift Down</button>
+
+    <button type="button" class="btn btn-default tooltip-right btn-bottom-left" bs-popover data-title="This should be shifted up" data-placement="right" data-trigger="hover">Shift Up</button>
+    <button type="button" class="btn btn-default tooltip-right btn-bottom-right" bs-popover data-title="This should be shifted left" data-placement="top" data-trigger="hover">Shift Left</button>
+    
+    <div class="container-viewport">
+      <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted to the right" data-placement="bottom" data-viewport="'.container-viewport'" data-trigger="hover">Shift Right</button>
+      <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted down" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}" data-trigger="hover">Shift Down</button>
+      <button type="button" class="btn btn-default" bs-popover data-title="This should be shifted down" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}" data-trigger="hover" data-animation="am-slide-top">Shift Down w/ Animation</button>
+      <button type="button" class="btn btn-default" bs-popover data-title="This should not be shifted down" data-placement="right" data-viewport="null" data-trigger="hover">Don't Shift Down</button>
+
+      <button type="button" class="btn btn-default pull-right" bs-popover data-title="This should be shifted to the left" data-placement="bottom" data-viewport="{selector: '.container-viewport', padding: 2}" data-trigger="hover">Shift Left</button>
+
+      <button type="button" class="btn btn-default tooltip-viewport-right btn-bottom-left" bs-popover data-title="This should be shifted up" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}" data-trigger="hover">Shift Up</button>
+      <button type="button" class="btn btn-default tooltip-viewport-right btn-bottom-right" bs-popover data-title="This should be shifted left" data-placement="top" data-viewport="{selector: '.container-viewport', padding: 2}" data-trigger="hover">Shift Left</button>
+    </div>
+</body>
+</html>

--- a/docs/tooltip-viewport.html
+++ b/docs/tooltip-viewport.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en" ng-app="viewport">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Tooltip Viewport Example</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+  
+  <link href="bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet">
+  <link href="bower_components/bootstrap-additions/dist/bootstrap-additions.css" rel="stylesheet">
+
+  <link rel="stylesheet" href="bower_components/highlightjs/styles/github.css">
+  <link rel="stylesheet" href="bower_components/angular-motion/dist/angular-motion.css">
+  <link rel="stylesheet" href="bower_components/bootstrap-additions/dist/bootstrap-additions.css">
+
+  <style>
+    body {
+      height: 1200px;
+    }
+    .tooltip {
+      min-width: 250px;
+      max-width: 500px;
+    }
+    .tooltip .tooltip-inner {
+      min-width: 250px;
+      max-width: 500px;
+      min-height: 100px;
+      text-align: left;
+    }
+    .container-viewport {
+      position: absolute;
+      top: 100px;
+      right: 250px;
+      left: 250px;
+      height: 300px;
+      background-color: #eee;
+    }
+    .btn-bottom-left {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+    
+    .btn-bottom-right {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+    }
+  </style>
+   
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-sanitize.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-animate.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.10/angular-route.min.js"></script>
+
+  <script src="scripts/angular-strap.tpl.js"></script>
+  
+  <script src="module.js"></script>
+  <script src="helpers/raf.js"></script>
+  <script src="helpers/dimensions.js"></script>
+  <script src="helpers/debounce.js"></script>
+  <script src="helpers/parse-options.js"></script>
+  <script src="helpers/date-parser.js"></script>
+  <script src="modal/modal.js"></script>
+  <script src="aside/aside.js"></script>
+  <script src="alert/alert.js"></script>
+  <script src="button/button.js"></script>
+  <script src="select/select.js"></script>
+  <script src="datepicker/datepicker.js"></script>
+  <script src="timepicker/timepicker.js"></script>
+  <script src="navbar/navbar.js"></script>
+  <script src="tooltip/tooltip.js"></script>
+  <script src="popover/popover.js"></script>
+  <script src="dropdown/dropdown.js"></script>
+  <script src="typeahead/typeahead.js"></script>
+  <script src="scrollspy/scrollspy.js"></script>
+  <script src="affix/affix.js"></script>
+  <script src="tab/tab.js"></script>
+  <script src="collapse/collapse.js"></script>
+   
+  <script>
+    angular.module('viewport', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStrap.popover', 'ngAnimate']);
+  </script>
+</head>
+<body>
+    <button type="button" class="btn btn-default pull-right" bs-tooltip data-title="This should be shifted to the left" data-placement="bottom">Shift Left</button>
+    <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted to the right" data-placement="bottom">Shift Right</button>
+    <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted down" data-placement="right">Shift Down</button>
+    <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted down" data-placement="right" data-animation="am-flip-x">Shift Down w/ Animation</button>
+    <button type="button" class="btn btn-default" bs-tooltip data-title="This should not be shifted down" data-placement="right" data-viewport="null">Don't Shift Down</button>
+
+    <button type="button" class="btn btn-default tooltip-right btn-bottom-left" bs-tooltip data-title="This should be shifted up" data-placement="right">Shift Up</button>
+    <button type="button" class="btn btn-default tooltip-right btn-bottom-right" bs-tooltip data-title="This should be shifted left" data-placement="top">Shift Left</button>
+
+    <div class="container-viewport">
+      <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted to the right" data-placement="bottom" data-viewport="{selector: '.container-viewport', padding: 2}">Shift Right</button>
+      <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted down" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}">Shift Down</button>
+      <button type="button" class="btn btn-default" bs-tooltip data-title="This should be shifted down" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}" data-animation="am-slide-top">Shift Down w/ Animation</button>
+      <button type="button" class="btn btn-default" bs-tooltip data-title="This should not be shifted down" data-placement="right" data-viewport="null">Don't Shift Down</button>
+
+      <button type="button" class="btn btn-default pull-right" bs-tooltip data-title="This should be shifted to the left" data-placement="bottom" data-viewport="{selector: '.container-viewport', padding: 2}">Shift Left</button>
+
+      <button type="button" class="btn btn-default tooltip-viewport-right btn-bottom-left" bs-tooltip data-title="This should be shifted up" data-placement="right" data-viewport="{selector: '.container-viewport', padding: 2}">Shift Up</button>
+      <button type="button" class="btn btn-default tooltip-viewport-right btn-bottom-right" bs-tooltip data-title="This should be shifted left" data-placement="top" data-viewport="{selector: '.container-viewport', padding: 2}">Shift Left</button>
+    </div>
+</body>
+</html>

--- a/src/helpers/dimensions.js
+++ b/src/helpers/dimensions.js
@@ -50,6 +50,69 @@ angular.module('mgcrea.ngStrap.helpers.dimensions', [])
         left: boxRect.left + (window.pageXOffset || docElement.documentElement.scrollLeft) - (docElement.documentElement.clientLeft || 0)
       };
     };
+  
+    /**
+     * Provides set equivalent of jQuery's offset function:
+     * @required-by bootstrap-tooltip
+     * @url http://api.jquery.com/offset/
+     * @param element
+     * @param options
+     * @param i
+     */
+    fn.setOffset = function (element, options, i) {
+      var curPosition,
+          curLeft,
+          curCSSTop,
+          curTop,
+          curOffset,
+          curCSSLeft,
+          calculatePosition,
+          position = fn.css(element, 'position'),
+          curElem = angular.element(element),
+          props = {};
+      
+      // Set position first, in-case top/left are set even on static elem
+      if (position === 'static') {
+        element.style.position = 'relative';
+      }
+      
+      curOffset = fn.offset(element);
+      curCSSTop = fn.css(element, 'top');
+      curCSSLeft = fn.css(element, 'left');
+      calculatePosition = (position === 'absolute' || position === 'fixed') && 
+                          (curCSSTop + curCSSLeft).indexOf('auto') > -1;
+      
+      // Need to be able to calculate position if either
+      // top or left is auto and position is either absolute or fixed
+      if (calculatePosition) {
+        curPosition = fn.position(element);
+        curTop = curPosition.top;
+        curLeft = curPosition.left;
+      } else {
+        curTop = parseFloat(curCSSTop) || 0;
+        curLeft = parseFloat(curCSSLeft) || 0;
+      }
+      
+      if (angular.isFunction(options)) {
+        options = options.call(element, i, curOffset);
+      }
+      
+      if (options.top !== null ) {
+        props.top = (options.top - curOffset.top) + curTop;
+      }
+      if ( options.left !== null ) {
+        props.left = (options.left - curOffset.left) + curLeft;
+      }
+
+      if ('using' in options) {
+        options.using.call(curElem, props);
+      } else {
+        curElem.css({
+          top: props.top + 'px',
+          left: props.left + 'px'
+        });
+      }
+    };
 
     /**
      * Provides read-only equivalent of jQuery's position function

--- a/src/helpers/test/dimensions.spec.js
+++ b/src/helpers/test/dimensions.spec.js
@@ -97,6 +97,21 @@ describe('dimensions', function () {
     });
 
   });
+  
+  describe('fn.setOffset', function () {
+
+    it('should correctly match jQuery output for every template', function () {
+      angular.forEach(templates, function(template, name) {
+        var element = compileDirective(name);
+        if(!element.is('.btn')) element = element.find('.btn:first');
+        var offset = dimensions.offset(element[0]);
+        var jQueryOffset = element.offset();
+        expect(offset.top).toBe(jQueryOffset.top);
+        expect(offset.left).toBe(jQueryOffset.left);
+      });
+    });
+
+  });
 
   describe('fn.position', function () {
 

--- a/src/popover/docs/popover.demo.html
+++ b/src/popover/docs/popover.demo.html
@@ -181,6 +181,16 @@
             The popover instance id for usage in event handlers.
           </td>
         </tr>
+        <tr>
+          <td>viewport</td>
+          <td>string | object</td>
+          <td>{ selector: 'body', padding: 0 }</td> 	 	 	
+          <td>
+            <p>
+              Keeps the popover within the bounds of this element. Example: viewport: '#viewport' or { "selector": "#viewport", "padding": 0 }
+            </p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -88,6 +88,12 @@ angular.module('mgcrea.ngStrap.popover', ['mgcrea.ngStrap.tooltip'])
           if(angular.isString(newValue)) newValue = !!newValue.match(/true|,?(popover),?/i);
           newValue === true ? popover.show() : popover.hide();
         });
+        
+        // Viewport support
+        attr.viewport && scope.$watch(attr.viewport, function (newValue) {
+          if(!popover || !angular.isDefined(newValue)) return;
+          popover.setViewport(newValue);
+        });
 
         // Initialize popover
         var popover = $popover(element, options);

--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -169,6 +169,16 @@
             The tooltip instance id for usage in event handlers.
           </td>
         </tr>
+        <tr>
+          <td>viewport</td>
+          <td>string | object</td>
+          <td>{ selector: 'body', padding: 0 }</td> 	 	 	
+          <td>
+            <p>
+              Keeps the tooltip within the bounds of this element. Example: viewport: '#viewport' or { "selector": "#viewport", "padding": 0 }
+            </p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -67,55 +67,73 @@ describe('tooltip', function() {
       element: '<a data-animation="am-flip-x" bs-tooltip="tooltip">hover me</a>'
     },
     'options-placement-top': {
-      element: '<a data-placement="top" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="top" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-right': {
-      element: '<a data-placement="right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="right" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-bottom': {
-      element: '<a data-placement="bottom" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="bottom" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-left': {
-      element: '<a data-placement="left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-exotic-top-left': {
-      element: '<a data-placement="top-left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="top-left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-exotic-top-right': {
-      element: '<a data-placement="top-right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="top-right" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-exotic-bottom-left': {
-      element: '<a data-placement="bottom-left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="bottom-left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-exotic-bottom-right': {
-      element: '<a data-placement="bottom-right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="bottom-right" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto': {
-      element: '<a data-placement="auto" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-top': {
-      element: '<a data-placement="auto top" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto top" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-right': {
-      element: '<a data-placement="auto right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto right" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-bottom': {
-      element: '<a data-placement="auto bottom" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto bottom" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-left': {
-      element: '<a data-placement="auto left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-exotic-top-left': {
-      element: '<a data-placement="auto top-left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto top-left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-exotic-top-right': {
-      element: '<a data-placement="auto top-right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto top-right" bs-tooltip="tooltip"data-viewport="null" >hover me</a>'
     },
     'options-placement-auto-exotic-bottom-left': {
-      element: '<a data-placement="auto bottom-left" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto bottom-left" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
     },
     'options-placement-auto-exotic-bottom-right': {
-      element: '<a data-placement="auto bottom-right" bs-tooltip="tooltip">hover me</a>'
+      element: '<a data-placement="auto bottom-right" bs-tooltip="tooltip" data-viewport="null">hover me</a>'
+    },
+    'options-placement-viewport-top': {
+      element: '<a data-placement="top" bs-tooltip="tooltip" data-viewport="\'#sandbox\'">hover me</a>'
+    },
+    'options-placement-viewport-right': {
+      element: '<a data-placement="right" bs-tooltip="tooltip" data-viewport="\'#sandbox\'">hover me</a>'
+    },
+    'options-placement-viewport-bottom': {
+      element: '<a data-placement="bottom" bs-tooltip="tooltip" data-viewport="\'#sandbox\'">hover me</a>'
+    },
+    'options-placement-viewport-left': {
+      element: '<a data-placement="left" bs-tooltip="tooltip" data-viewport="\'#sandbox\'">hover me</a>'
+    },
+    'options-placement-viewport-padding': {
+      element: '<a data-placement="right" bs-tooltip="tooltip" data-viewport="{ selector: \'#sandbox\', padding: 10 }">hover me</a>'
+    },
+    'options-placement-viewport-exotic': {
+      element: '<a data-placement="bottom-right" bs-tooltip="tooltip" data-viewport="{ selector: \'#sandbox\', padding: 10 }">hover me</a>'
     },
     'options-trigger': {
       element: '<a data-trigger="click" bs-tooltip="tooltip">click me</a>'
@@ -734,11 +752,9 @@ describe('tooltip', function() {
           var elm = compileDirective('options-placement-auto-top');
           angular.element(elm[0]).triggerHandler('mouseenter');
 
-          // set the offset to 0 so we don't trigger changing the placement
-          spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-            if (prop === 'offsetWidth') return 0;
-            if (prop === 'offsetHeight') return 0;
-          });
+          // need to change the width and height so we don't trigger
+          // the repositioning
+          sandboxEl.children('.tooltip').css({ width: 0, height: 0 });
 
           $$rAF.flush();
           expect(sandboxEl.children('.tooltip').hasClass('top')).toBeTruthy();
@@ -748,11 +764,9 @@ describe('tooltip', function() {
           var elm = compileDirective('options-placement-auto-exotic-top-left');
           angular.element(elm[0]).triggerHandler('mouseenter');
 
-          // set the offset to 0 so we don't trigger changing the placement
-          spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-            if (prop === 'offsetWidth') return 0;
-            if (prop === 'offsetHeight') return 0;
-          });
+         // need to change the width and height so we don't trigger
+          // the repositioning
+          sandboxEl.children('.tooltip').css({ width: 0, height: 0 });
 
           $$rAF.flush();
           expect(sandboxEl.children('.tooltip').hasClass('top-left')).toBeTruthy();
@@ -762,11 +776,9 @@ describe('tooltip', function() {
           var elm = compileDirective('options-placement-auto');
           angular.element(elm[0]).triggerHandler('mouseenter');
 
-          // set the offset to 0 so we don't trigger changing the placement
-          spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-            if (prop === 'offsetWidth') return 0;
-            if (prop === 'offsetHeight') return 0;
-          });
+          // need to change the width and height so we don't trigger
+          // the repositioning
+          sandboxEl.children('.tooltip').css({ width: 0, height: 0 });
 
           $$rAF.flush();
           expect(sandboxEl.children('.tooltip').hasClass('top')).toBeTruthy();
@@ -849,7 +861,6 @@ describe('tooltip', function() {
 
     });
 
-
     describe('contentTemplate', function() {
 
       it('should support custom contentTemplate', function() {
@@ -874,242 +885,308 @@ describe('tooltip', function() {
       });
     });
 
-  });
+    describe('viewport', function () {
+      it('should default the viewport to body with a padding of 0 when not set', function () {
+        var myTooltip = $tooltip(sandboxEl, {});
+        var tipOptions = myTooltip.$options;
 
-  describe('standard placements', function() {
-    var dimensions;
-
-    beforeEach(inject (function (_dimensions_) {
-      dimensions = _dimensions_;
-
-      // Spy on the dimensions object so we can control the placement
-      // and ensure things are calcing as we expect
-      spyOn(dimensions, 'position').and.callFake(function () {
-        return { top: 10, left: 10, height: 20, width: 100 };
-      });
-    }));
-
-    it('should be placed off screen till its been positioned', function () {
-      var elm = compileDirective('options-placement-top');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      var tip = sandboxEl.children('.tooltip');
-      expect(tip[0].style.top).toBe('-9999px');
-      expect(tip[0].style.left).toBe('-9999px');
-    });
-
-    it('should position the tooltip above the target when placement is `top`', function () {
-      var elm = compileDirective('options-placement-top');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
+        expect(tipOptions.viewport.selector).toBe('body');
+        expect(tipOptions.viewport.padding).toBe(0);
       });
 
-      $$rAF.flush();
+      it('should support using an element', function () {
+        var myViewport = angular.element(document.createElement('div'));
+        var myTooltip = $tooltip(sandboxEl, { viewport: myViewport });
+        var tipOptions = myTooltip.$options;
 
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('-10px')
-      expect(tipElement[0].style.left).toBe('35px')
-    });
-
-    it('should position the tooltip to the right of the target when placement is `right`', function () {
-      var elm = compileDirective('options-placement-right');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
+        expect(tipOptions.viewport).toBe(myViewport);
       });
+      
+      it('should support specifying a selector and padding', function () {
+        var myViewport = { selector: '#someSelector', padding: 100 };
+        var myTooltip = $tooltip(sandboxEl, { viewport: myViewport });
+        var tipOptions = myTooltip.$options;
 
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('10px')
-      expect(tipElement[0].style.left).toBe('110px')
-    });
-
-    it('should position the tooltip below the target when placement is `bottom`', function () {
-      var elm = compileDirective('options-placement-bottom');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
+        expect(tipOptions.viewport.selector).toBe('#someSelector');
+        expect(tipOptions.viewport.padding).toBe(100);
       });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('30px')
-      expect(tipElement[0].style.left).toBe('35px')
-    });
-
-    it('should position the tooltip to the left of the target when placement is `left`', function () {
-      var elm = compileDirective('options-placement-left');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('10px')
-      expect(tipElement[0].style.left).toBe('-40px')
-    });
-
-    it('should position the tooltip to the top-left of the target when placement is `top-left`', function () {
-      var elm = compileDirective('options-placement-exotic-top-left');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('-10px')
-      expect(tipElement[0].style.left).toBe('10px')
-    });
-
-    it('should position the tooltip to the top-right of the target when placement is `top-right`', function () {
-      var elm = compileDirective('options-placement-exotic-top-right');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('-10px')
-      expect(tipElement[0].style.left).toBe('60px')
-    });
-
-    it('should position the tooltip to the bottom-left of the target when placement is `bottom-left`', function () {
-      var elm = compileDirective('options-placement-exotic-bottom-left');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('30px')
-      expect(tipElement[0].style.left).toBe('10px')
-    });
-
-    it('should position the tooltip to the bottom-right of the target when placement is `bottom-right`', function () {
-      var elm = compileDirective('options-placement-exotic-bottom-right');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('30px')
-      expect(tipElement[0].style.left).toBe('60px')
     });
   });
+  
+  describe('placements', function () {
+    function calculatePlacements(placements, styleEl) {
+      if (styleEl) {
+        bodyEl.append(styleEl);  
+      }
+      
+      for (var placement in placements) {
+        var elm = compileDirective(placement);
+        angular.element(elm[0]).triggerHandler('mouseenter');
 
-  describe('auto placements', function() {
-    var dimensions,
-        $window
+        // Find the tip in the sandbox and grab it's 
+        // top and left styles
+        var tipElement = sandboxEl.children('.tooltip')[0];
+        placements[placement] = {
+          top: tipElement.style.top,
+          left: tipElement.style.left,
+        }
+        
+        // Clear the sandbox after we've rendered
+        // each tooltip
+        sandboxEl.html('');
+      }
+      if (styleEl) {
+        styleEl.remove();  
+      }
 
-    beforeEach(inject (function (_dimensions_, _$window_) {
-      dimensions = _dimensions_;
-      $window = _$window_;
-    }));
-
-    it('should position the tooltip below the target when initial placement results in positioning off screen', function () {
-      var elm = compileDirective('options-placement-auto-top');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(dimensions, 'position').and.callFake(function () {
-        return { top: 10, right: 110, bottom: 30, left: 10, height: 20, width: 100 };
-      });
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('30px')
-      expect(tipElement[0].style.left).toBe('35px')
+      return placements;
+    };
+    
+    var standardPlacements,
+        autoPlacements,
+        viewportPlacements;
+    
+    beforeEach(function () {
+      var styleEl = $('<style>' +
+                      '    body { padding: 0; margin: 0; } ' + 
+                      '    #sandbox { height: 100px; width: 100px; } ' + 
+                      '    a { display: inline-block; height: 20px; width: 20px; } ' + 
+                      '    .tooltip { height: 100px; width: 200px; position: absolute; } ' +  // Tooltip is purposely bigger than sandbox to trigger auto placement
+                      '</style>');
+      
+      standardPlacements = calculatePlacements({
+        'options-placement-top': {},
+        'options-placement-right': {},
+        'options-placement-bottom': {},
+        'options-placement-left': {},
+        'options-placement-exotic-top-left': {},
+        'options-placement-exotic-top-right': {},
+        'options-placement-exotic-bottom-left': {},
+        'options-placement-exotic-bottom-right': {},
+      }, styleEl);
+      
+      autoPlacements = calculatePlacements({
+        'options-placement-auto-top': {},
+        'options-placement-auto-right': {},
+        'options-placement-auto-bottom': {},
+        'options-placement-auto-left': {},
+        'options-placement-auto-exotic-top-left': {},
+        'options-placement-auto-exotic-top-right': {},
+        'options-placement-auto-exotic-bottom-left': {},
+        'options-placement-auto-exotic-bottom-right': {},
+      }, styleEl);
+      
+      // Change the style for viewport testing
+      styleEl = $('<style>' +
+                  '    body { padding: 0; margin: 0; } ' + 
+                  '    #sandbox { height: 200px; width: 200px; position: absolute; top: 100px; left: 100px; } ' + 
+                  '    a { display: inline-block; height: 20px; width: 20px; position: absolute; } ' + 
+                  '    .tooltip { height: 100px; width: 100px; position: absolute; } ' + 
+                  '    a[data-placement="top"] { bottom: 0; left: 0; } ' +
+                  '    a[data-placement="right"] { top: 0; left: 0; } ' +
+                  '    a[data-placement="bottom"] { top: 0; right: 0; } ' +
+                  '    a[data-placement="left"] { bottom: 0; right: 0; } ' +
+                  '</style>');
+      
+      viewportPlacements = calculatePlacements({
+        'options-placement-viewport-top': {},
+        'options-placement-viewport-right': {},
+        'options-placement-viewport-bottom': {},
+        'options-placement-viewport-left': {},
+        'options-placement-viewport-padding': {},
+        'options-placement-viewport-exotic': {},
+      }, styleEl);
     });
+    
+    describe('default placement', function () {
+      it('should be placed off screen till its been positioned', inject(function (dimensions) {
+        // Spy on setOffset and make it do nothing.  That way
+        // the initial position is maintained.  
+        spyOn(dimensions, 'setOffset').and.callFake(function () {});
 
-    it('should position the tooltip above the target when initial placement results in positioning off screen', function () {
-      var elm = compileDirective('options-placement-auto-bottom');
-      angular.element(elm[0]).triggerHandler('mouseenter');
+        var elm = compileDirective('options-placement-top');
+        angular.element(elm[0]).triggerHandler('mouseenter');
 
-      spyOn(dimensions, 'position').and.callFake(function () {
-        return { top: 10, right: 110, bottom: 30, left: 10, height: 20, width: 100 };
-      });
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
-      });
-
-      $$rAF.flush();
-
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('-10px')
-      expect(tipElement[0].style.left).toBe('35px')
+        var tip = sandboxEl.children('.tooltip')[0];
+        expect(tip.style.top).toBe('-9999px');
+        expect(tip.style.left).toBe('-9999px');
+      })); 
     });
+    
+    describe('standard placements', function() {
+      it('should position the tooltip above the target when placement is `top`', function () {
+        var placement = standardPlacements['options-placement-top'];
 
-    it('should position the tooltip to the right of the target when initial placement results in positioning off screen', function () {
-      var elm = compileDirective('options-placement-auto-left');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(dimensions, 'position').and.callFake(function () {
-        return { top: 10, right: 110, bottom: 30, left: 10, height: 20, width: 100 };
-      });
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
+        expect(placement.top).toBe('-100px'); 
+        expect(placement.left).toBe('-90px');
       });
 
-      $$rAF.flush();
+      it('should position the tooltip to the right of the target when placement is `right`', function () {
+        var placement = standardPlacements['options-placement-right'];
 
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('10px')
-      expect(tipElement[0].style.left).toBe('110px')
+        expect(placement.top).toBe('-40px');
+        expect(placement.left).toBe('20px');
+      });
+
+      it('should position the tooltip below the target when placement is `bottom`', function () {
+        var placement = standardPlacements['options-placement-bottom'];
+
+        expect(placement.top).toBe('20px');
+        expect(placement.left).toBe('-90px');
+      });
+
+      it('should position the tooltip to the left of the target when placement is `left`', function () {
+        var placement = standardPlacements['options-placement-left'];
+
+        expect(placement.top).toBe('-40px');
+        expect(placement.left).toBe('-200px');
+      });
+
+      it('should position the tooltip to the top-left of the target when placement is `top-left`', function () {
+        var placement = standardPlacements['options-placement-exotic-top-left'];
+
+        expect(placement.top).toBe('-100px');
+        expect(placement.left).toBe('0px');
+      });
+
+      it('should position the tooltip to the top-right of the target when placement is `top-right`', function () {
+        var placement = standardPlacements['options-placement-exotic-top-right'];
+
+        expect(placement.top).toBe('-100px');
+        expect(placement.left).toBe('-180px');
+      });
+
+      it('should position the tooltip to the bottom-left of the target when placement is `bottom-left`', function () {
+        var placement = standardPlacements['options-placement-exotic-bottom-left'];
+
+        expect(placement.top).toBe('20px');
+        expect(placement.left).toBe('0px');
+      });
+
+      it('should position the tooltip to the bottom-right of the target when placement is `bottom-right`', function () {
+        var placement = standardPlacements['options-placement-exotic-bottom-right'];
+
+        expect(placement.top).toBe('20px');
+        expect(placement.left).toBe('-180px');
+      });
     });
-
-    it('should position the tooltip to the left of the target when initial placement results in positioning off screen', function () {
-      var elm = compileDirective('options-placement-auto-right');
-      angular.element(elm[0]).triggerHandler('mouseenter');
-
-      spyOn(dimensions, 'position').and.callFake(function () {
-        return { top: 10, right: 110, bottom: 30, left: 10, height: 20, width: 100 };
-      });
-      spyOn(angular.element.prototype, 'prop').and.callFake(function (prop) {
-        if (prop === 'offsetWidth') return 50;
-        if (prop === 'offsetHeight') return 20;
+    
+    describe('auto placements', function () {
+      it('should position the tooltip below the target when initial placement results in positioning outside its container', function () {
+        var autoTop = autoPlacements['options-placement-auto-top'];
+        var bottom = standardPlacements['options-placement-bottom'];
+        
+        // top is offscreen, so it should swap to bottom and match the standard bottom
+        expect(autoTop.top).toBe(bottom.top)
+        expect(autoTop.left).toBe(bottom.left)
       });
 
-      $$rAF.flush();
+      it('should position the tooltip to the left of the target when initial placement results in positioning outside its container', function () {
+        var autoRight = autoPlacements['options-placement-auto-right'];
+        var left = standardPlacements['options-placement-left'];
 
-      var tipElement = sandboxEl.children('.tooltip');
-      expect(tipElement[0].style.top).toBe('10px')
-      expect(tipElement[0].style.left).toBe('-40px')
+        // right is offscreen, so it should swap to left and match the standard left
+        expect(autoRight.top).toBe(left.top)
+        expect(autoRight.left).toBe(left.left)
+      });
+
+      it('should position the tooltip above the target when initial placement results in positioning outside its container', function () {
+        var autoBottom = autoPlacements['options-placement-auto-bottom'];
+        var top = standardPlacements['options-placement-top'];
+        
+        // bottom is offscreen, so it should swap to top and match the standard top
+        expect(autoBottom.top).toBe(top.top)
+        expect(autoBottom.left).toBe(top.left)
+      });
+
+      it('should position the tooltip to the right of the target when initial placement results in positioning outside its container', function () {
+        var autoLeft = autoPlacements['options-placement-auto-left'];
+        var right = standardPlacements['options-placement-right'];
+
+        // left is offscreen, so it should swap to right and match the standard right
+        expect(autoLeft.top).toBe(right.top)
+        expect(autoLeft.left).toBe(right.left)
+      });
+
+      it('should position the tooltip to the bottom-left of the target when initial placement results in positioning outside its container', function () {
+        var autoTopRight = autoPlacements['options-placement-auto-exotic-top-right'];
+        var bottomLeft = standardPlacements['options-placement-exotic-bottom-left'];
+        
+        // should swap to bottom-left and match the standard bottom-left
+        expect(autoTopRight.top).toBe(bottomLeft.top)
+        expect(autoTopRight.left).toBe(bottomLeft.left)
+      });
+
+      it('should position the tooltip to the bottom-right of the target when initial placement results in positioning outside its container', function () {
+        var autoTopLeft = autoPlacements['options-placement-auto-exotic-top-left'];
+        var bottomRight = standardPlacements['options-placement-exotic-bottom-right'];
+
+        // should swap to bottom-right and match the standard bottom-right
+        expect(autoTopLeft.top).toBe(bottomRight.top)
+        expect(autoTopLeft.left).toBe(bottomRight.left)
+      });
+
+      it('should position the tooltip to the top-left of the target when initial placement results in positioning outside its container', function () {
+        var autoBottomRight = autoPlacements['options-placement-auto-exotic-bottom-right'];
+        var topLeft = standardPlacements['options-placement-exotic-top-left'];
+
+        // should swap to top-left and match the standard top-left
+        expect(autoBottomRight.top).toBe(topLeft.top)
+        expect(autoBottomRight.left).toBe(topLeft.left)
+      });
+
+      it('should position the tooltip to the top-left of the target when initial placement results in positioning outside its container', function () {
+        var autoBottomLeft = autoPlacements['options-placement-auto-exotic-bottom-left'];
+        var topRight = standardPlacements['options-placement-exotic-top-right'];
+
+        // should swap to top-right and match the standard top-right
+        expect(autoBottomLeft.top).toBe(topRight.top)
+        expect(autoBottomLeft.left).toBe(topRight.left)
+      });
+    });
+    
+    describe('viewport placements', function () {
+      it('should shift down when positioning results in being outsie of the viewport', function () {
+        var right = viewportPlacements['options-placement-viewport-right'];
+        
+        expect(right.top).toBe('0px');
+        expect(right.left).toBe('20px');
+      });
+         
+      it('should shift left when positioning results in being outside of the viewport', function () {
+        var bottom = viewportPlacements['options-placement-viewport-bottom'];
+        
+        expect(bottom.top).toBe('20px');
+        expect(bottom.left).toBe('100px');
+      });
+      
+      it('should shift right when positioning results in being outside of the viewport', function () {
+        var top = viewportPlacements['options-placement-viewport-top'];
+        
+        expect(top.top).toBe('80px');
+        expect(top.left).toBe('0px');
+      });
+      
+      it('should shift up when positioning results in being outside of the viewport', function () {
+        var top = viewportPlacements['options-placement-viewport-left'];
+        
+        expect(top.top).toBe('100px');
+        expect(top.left).toBe('80px');
+      });
+      
+      it('should use the padding to position the tooltip from the edge of the viewport', function () {
+        var padding = viewportPlacements['options-placement-viewport-padding'];
+        
+        expect(padding.top).toBe('10px');
+        expect(padding.left).toBe('20px');
+      });
+      
+      it('should ignore exotic placements', function () {
+        var exotic = viewportPlacements['options-placement-viewport-exotic'];
+        
+        expect(exotic.top).toBe('20px');
+        expect(exotic.left).toBe('-80px');
+      });
     });
   });
 });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -22,7 +22,11 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
       type: '',
       delay: 0,
       autoClose: false,
-      bsEnabled: true
+      bsEnabled: true,
+      viewport: {
+       selector: 'body',
+       padding: 0
+      }
     };
 
     this.$get = function($window, $rootScope, $compile, $q, $templateCache, $http, $animate, $sce, dimensions, $$rAF, $timeout) {
@@ -211,19 +215,28 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           // Options: custom classes
           if(options.customClass) tipElement.addClass(options.customClass);
 
+          // Append the element, without any animations.  If we append
+          // using $animate.enter, some of the animations cause the placement
+          // to be off due to the transforms.
+          after ? after.after(tipElement) : parent.prepend(tipElement);
+          
+          $tooltip.$isShown = scope.$isShown = true;
+          safeDigest(scope);
+          
+          // Now, apply placement
+          $tooltip.$applyPlacement();
+          
+          // Once placed, animate it.
           // Support v1.3+ $animate
           // https://github.com/angular/angular.js/commit/bf0f5502b1bbfddc5cdd2f138efd9188b8c652a9
           var promise = $animate.enter(tipElement, parent, after, enterAnimateCallback);
           if(promise && promise.then) promise.then(enterAnimateCallback);
-
-          $tooltip.$isShown = scope.$isShown = true;
           safeDigest(scope);
+          
           $$rAF(function () {
-            $tooltip.$applyPlacement();
-
-            // Once placed, make the tooltip visible
+            // Once the tooltip is placed and the animation starts, make the tooltip visible
             if(tipElement) tipElement.css({visibility: 'visible'});
-          }); // var a = bodyEl.offsetWidth + 1; ?
+          });
 
           // Bind events
           if(options.keyboard) {
@@ -317,6 +330,10 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
         $tooltip.setEnabled = function(isEnabled) {
           options.bsEnabled = isEnabled;
         };
+        
+        $tooltip.setViewport = function(viewport) {
+          options.viewport = viewport;
+        };
 
         // Protected methods
 
@@ -335,17 +352,17 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           // Need to add the position class before we get
           // the offsets
           tipElement.addClass(options.placement);
-
+          
           // Get the position of the target element
           // and the height and width of the tooltip so we can center it.
           var elementPosition = getPosition(),
               tipWidth = tipElement.prop('offsetWidth'),
               tipHeight = tipElement.prop('offsetHeight');
-
+          
           // If we're auto placing, we need to check the positioning
           if (autoPlace) {
             var originalPlacement = placement;
-            var container = options.container ? angular.element(document.querySelector(options.container)) : element.parent();
+            var container = options.container ? findElement(options.container) : element.parent();
             var containerPosition = getPosition(container);
 
             // Determine if the vertical placement
@@ -373,7 +390,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
           // Get the tooltip's top and left coordinates to center it with this directive.
           var tipPosition = getCalculatedOffset(placement, elementPosition, tipWidth, tipHeight);
-          applyPlacementCss(tipPosition.top, tipPosition.left);
+          applyPlacement(tipPosition, placement);
         };
 
         $tooltip.$onKeyUp = function(evt) {
@@ -473,7 +490,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
         function getPosition($element) {
           $element = $element || (options.target || element);
 
-          var el = $element[0];
+          var el = $element[0],
+              isBody = el.tagName === 'BODY';
 
           var elRect = el.getBoundingClientRect();
           var rect = {};
@@ -486,21 +504,17 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             }
           }
           
-          if (elRect.width === null) {
+          if (rect.width === null) {
             // width and height are missing in IE8, so compute them manually; see https://github.com/twbs/bootstrap/issues/14093
             rect = angular.extend({}, rect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top });
           }
+          var elOffset = isBody ? { top: 0, left: 0 } : dimensions.offset(el),
+              scroll = { scroll:  isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.prop('scrollTop') || 0 },
+              outerDims = isBody ? { width: document.documentElement.clientWidth, height: $window.innerHeight } : null;
 
-          var elPos;
-          if (options.container === 'body') {
-            elPos = dimensions.offset(el);
-          } else {
-            elPos = dimensions.position(el);
-          }
-
-          return angular.extend({}, rect, elPos);
+          return angular.extend({}, rect, scroll, outerDims, elOffset);
         }
-
+        
         function getCalculatedOffset(placement, position, actualWidth, actualHeight) {
           var offset;
           var split = placement.split('-');
@@ -554,12 +568,105 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
               offset.top = position.top + position.height;
             }
           }
-
+          
           return offset;
         }
 
-        function applyPlacementCss(top, left) {
-          tipElement.css({ top: top + 'px', left: left + 'px' });
+        function applyPlacement(offset, placement) {
+          var tip = tipElement[0],
+              width = tip.offsetWidth,
+              height = tip.offsetHeight;
+          
+          // manually read margins because getBoundingClientRect includes difference
+          var marginTop = parseInt(dimensions.css(tip, 'margin-top'), 10),
+              marginLeft = parseInt(dimensions.css(tip, 'margin-left'), 10);
+          
+          // we must check for NaN for ie 8/9
+          if (isNaN(marginTop)) marginTop  = 0;
+          if (isNaN(marginLeft)) marginLeft = 0;
+          
+          offset.top  = offset.top + marginTop;
+          offset.left = offset.left + marginLeft;
+          
+          // dimensions setOffset doesn't round pixel values
+          // so we use setOffset directly with our own function
+          dimensions.setOffset(tip, angular.extend({
+            using: function (props) {
+              tipElement.css({
+                top: Math.round(props.top) + 'px',
+                left: Math.round(props.left) + 'px'
+              });
+            }
+          }, offset), 0);
+          
+          // check to see if placing tip in new offset caused the tip to resize itself
+          var actualWidth = tip.offsetWidth,
+              actualHeight = tip.offsetHeight;
+         
+          if (placement === 'top' && actualHeight !== height) {
+            offset.top = offset.top + height - actualHeight;
+          }
+          
+          // If it's an exotic placement, exit now instead of 
+          // applying a delta and changing the arrow
+          if (/top-left|top-right|bottom-left|bottom-right/.test(placement)) return;
+          
+          var delta = getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight);
+          
+          if (delta.left) {
+            offset.left += delta.left;
+          } else { 
+            offset.top += delta.top;
+          }
+          
+          dimensions.setOffset(tip, offset);
+          
+          if (/top|right|bottom|left/.test(placement)) {
+            var isVertical = /top|bottom/.test(placement),
+                arrowDelta = isVertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight,
+                arrowOffsetPosition = isVertical ? 'offsetWidth' : 'offsetHeight';
+            
+            replaceArrow(arrowDelta, tip[arrowOffsetPosition], isVertical);    
+          }
+        }
+        
+        function getViewportAdjustedDelta(placement, position, actualWidth, actualHeight) {
+          var delta = { top: 0, left: 0 },
+              $viewport = options.viewport && findElement(options.viewport.selector || options.viewport);
+          
+          if (!$viewport) {
+           return delta; 
+          }
+          
+          var viewportPadding = options.viewport && options.viewport.padding || 0,
+              viewportDimensions = getPosition($viewport);
+          
+          if (/right|left/.test(placement)) {
+            var topEdgeOffset    = position.top - viewportPadding - viewportDimensions.scroll,
+                bottomEdgeOffset = position.top + viewportPadding - viewportDimensions.scroll + actualHeight;
+            if (topEdgeOffset < viewportDimensions.top) { // top overflow
+              delta.top = viewportDimensions.top - topEdgeOffset;
+            } else if (bottomEdgeOffset > viewportDimensions.top + viewportDimensions.height) { // bottom overflow
+              delta.top = viewportDimensions.top + viewportDimensions.height - bottomEdgeOffset;
+            }
+          } else {
+            var leftEdgeOffset  = position.left - viewportPadding,
+                rightEdgeOffset = position.left + viewportPadding + actualWidth;
+            if (leftEdgeOffset < viewportDimensions.left) { // left overflow
+              delta.left = viewportDimensions.left - leftEdgeOffset;
+            } else if (rightEdgeOffset > viewportDimensions.width) { // right overflow
+              delta.left = viewportDimensions.left + viewportDimensions.width - rightEdgeOffset;
+            }
+          }
+
+          return delta;
+        }
+        
+        function replaceArrow(delta, dimension, isHorizontal) {
+          var $arrow = findElement('.tooltip-arrow, .arrow', tipElement[0]);
+          
+          $arrow.css(isHorizontal ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
+                .css(isHorizontal ? 'top' : 'left', '');
         }
 
         function destroyTipElement() {
@@ -680,6 +787,12 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           if(!tooltip || !angular.isDefined(newValue)) return;
           if(angular.isString(newValue)) newValue = !!newValue.match(/true|1|,?(tooltip),?/i);
           newValue === false ? tooltip.setEnabled(false) : tooltip.setEnabled(true);
+        });
+        
+        // Viewport support
+        attr.viewport && scope.$watch(attr.viewport, function (newValue) {
+          if(!tooltip || !angular.isDefined(newValue)) return;
+          tooltip.setViewport(newValue);
         });
 
         // Initialize popover


### PR DESCRIPTION
Adds support for keeping tooltips and dependent controls inside the
viewport.  Follows the Bootstrap implementation.  This closes issue #1207.