### PR TITLE
feat(timepicker): add option to floor minutes display to nearest 5 minut...

### DIFF
--- a/src/timepicker/docs/timepicker.demo.html
+++ b/src/timepicker/docs/timepicker.demo.html
@@ -236,6 +236,14 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
           </td>
         </tr>
         <tr>
+          <td>roundDisplay</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Whether the picker should round the minute values displayed when no initial time is specified. The rounding is made by dividing time in minuteStep intervals and flooring the current time to the nearest.</p>
+          </td>
+        </tr>
+        <tr>
           <td>iconUp</td>
           <td>string</td>
           <td>'glyphicon glyphicon-chevron-up'</td>

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -121,6 +121,9 @@ describe('timepicker', function() {
       scope: {selectedTime: new Date(1970, 0, 1, 10, 30), arrowBehavior: 'pager'},
       element: '<input type="text" ng-model="selectedTime" length="5" data-arrow-behavior="{{ arrowBehavior }}" bs-timepicker>'
     },
+    'options-roundDisplay': {
+      element: '<input type="text" data-minute-step="15" ng-model="selectedTime" data-round-display="true" bs-timepicker>'
+    },
     'bsShow-attr': {
       scope: {selectedTime: new Date()},
       element: '<input type="text" ng-model="selectedTime" bs-timepicker bs-show="true">'
@@ -978,6 +981,19 @@ describe('timepicker', function() {
         expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'h'));
         sandboxEl.find('.dropdown-menu thead button:eq(0)').triggerHandler('click');
         expect(scope.selectedTime).toEqual(testTime);
+      });
+
+    });
+
+    describe('roundDisplay', function() {
+
+      it('should floor display minutes to nearest minuteStep interval when ngModel value is undefined', function() {
+        var elm = compileDirective('options-roundDisplay', { selectedTime: undefined });
+        var currentTime = new Date();
+        currentTime.setMinutes(currentTime.getMinutes() - currentTime.getMinutes() % 15);
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0)').text()).toBe(dateFilter(currentTime, 'h'));
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2)').text()).toBe(dateFilter(currentTime, 'mm'));
       });
 
     });

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -28,6 +28,7 @@ angular.module('mgcrea.ngStrap.timepicker', [
       length: 5,
       hourStep: 1,
       minuteStep: 5,
+      roundDisplay: false,
       iconUp: 'glyphicon glyphicon-chevron-up',
       iconDown: 'glyphicon glyphicon-chevron-down',
       arrowBehavior: 'pager'
@@ -52,10 +53,18 @@ angular.module('mgcrea.ngStrap.timepicker', [
           return $dateFormatter.formatDate(date, format, lang);
         };
 
+        function floorMinutes(time)
+        {
+          // coeff used to floor current time to nearest minuteStep interval
+          var coeff = 1000 * 60 * options.minuteStep;
+          return new Date(Math.floor(time.getTime() / coeff) * coeff);
+        }
+
         // View vars
 
         var selectedIndex = 0;
-        var startDate = controller.$dateValue || new Date();
+        var defaultDate = options.roundDisplay ? floorMinutes(new Date()) : new Date();
+        var startDate = controller.$dateValue || defaultDate;
         var viewDate = {hour: startDate.getHours(), meridian: startDate.getHours() < 12, minute: startDate.getMinutes(), second: startDate.getSeconds(), millisecond: startDate.getMilliseconds()};
 
         var format = $dateFormatter.getDatetimeFormat(options.timeFormat, lang);
@@ -348,6 +357,12 @@ angular.module('mgcrea.ngStrap.timepicker', [
         var options = {scope: scope, controller: controller};
         angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'timeType', 'timeFormat', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'id'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
+        });
+
+        // use string regex match for boolean values
+        var falseValueRegExp = /^(false|0|)$/;
+        angular.forEach(['roundDisplay'], function(key) {
+          if(angular.isDefined(attr[key])) options[key] = !falseValueRegExp.test(attr[key]);
         });
 
         // Visibility binding support


### PR DESCRIPTION
...es whole value

Adds a new option 'roundDisplay' that is checked when the initial time value specified by ngModel is not defined. Previously, the timepicker would use the current time in this case. With this new option, we can tell the picker to round the minutes value so we don't get times like 11:38 or 11:43, but instead get 11:35 or 11:40

Closes #1444