### PR TITLE
Missing validation against min|max date

### DIFF
--- a/dist/modules/datepicker.js
+++ b/dist/modules/datepicker.js
@@ -398,6 +398,10 @@ angular.module('mgcrea.ngStrap.datepicker', [
           //   date = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
           // }
           controller.$dateValue = date;
+          
+          //Trigger validation
+          validateAgainstMinMaxDate(date);
+          
           return getDateFormattedString();
         });
 


### PR DESCRIPTION
Validation against min|max date was performed only when value was changed by user's action (path "viewValue -> $parsers -> modelValue" )

But then value was changed in parental scope, for example by clicking button "copy date from some other object" then validation was not called. Result was that field still appeared as valid even when value was clearly outside of min|max boundaries.
