### PR TITLE
fix(tooltip): remove hasOwnProperty when iterating getBoundingRect

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -499,9 +499,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
           // IE8 has issues with angular.extend and using elRect directly.
           // By coping the values of elRect into a new object, we can continue to use extend
           for (var p in elRect) {
-            if (elRect.hasOwnProperty(p)) {
-              rect[p] = elRect[p];
-            }
+            // DO NOT use hasOwnProperty when inspecting the return of getBoundingClientRect.
+            rect[p] = elRect[p];
           }
 
           if (rect.width === null) {


### PR DESCRIPTION
When iterating the properties on the return value of getBoundingRect, hasOwnProperty is returning false causing the properties to not be copied into the new rect object.

Since the return value of getBoundingRect is frozen, we can safely remove the hasOwnPropertyCheck.  This should finally fully address #1447.