### PR TITLE
feat (bsDatepicker): observe date format

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -302,7 +302,12 @@ angular.module('mgcrea.ngStrap.datepicker', [
             validateAgainstMinMaxDate(controller.$dateValue);
           });
         });
-
+		
+		// Observe date format
+        angular.isDefined(attr['dateFormat']) && attr.$observe('dateFormat', function(newValue) {
+          datepicker.$options['dateFormat'] = newValue;
+        });
+		
         // Watch model for changes
         scope.$watch(attr.ngModel, function(newValue, oldValue) {
           datepicker.update(controller.$dateValue);


### PR DESCRIPTION
the date format is not fixed at initialisation time - useful when users should be able to pick a date format e.g. by changing locale