### PR TITLE
fix(modal backdrop): make z-index not conflict with aside

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -86,7 +86,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
         // Fetch, compile then initialize modal
         var modalLinker, modalElement;
         var backdropElement = angular.element('<div class="' + options.prefixClass + '-backdrop"/>');
-        backdropElement.css({position:'fixed', top:'0px', left:'0px', bottom:'0px', right:'0px', 'z-index': 1039});
+        backdropElement.css({position:'fixed', top:'0px', left:'0px', bottom:'0px', right:'0px', 'z-index': 1038});
         $modal.$promise.then(function(template) {
           if(angular.isObject(template)) template = template.data;
           if(options.html) template = template.replace(htmlReplaceRegExp, 'ng-bind-html="');


### PR DESCRIPTION
The bootstrap-additions code sets the aside z-index to bootstraps: @z-index-modal -1 which will be 1039 the next time you update using bootstrap 3.3.2. 1039 is the value I chose for the modal backdrop in 81f8654a9e92341eaf4d495ec132a1e6cf7743ca , so I'm moving the backdrop to 1038 to stay under aside.