### PR TITLE
docs(popover): fix $popover service sample call

### DIFF
--- a/src/popover/docs/popover.demo.js
+++ b/src/popover/docs/popover.demo.js
@@ -20,6 +20,6 @@ angular.module('mgcrea.ngStrapDocs')
 
   var myPopover = $popover(angular.element(document.querySelector('#popover-as-service')), asAServiceOptions);
   $scope.togglePopover = function() {
-    myPopover.$promise.then(myPopover.hide);
+    myPopover.$promise.then(myPopover.toggle);
   };
 });


### PR DESCRIPTION
$popover service sample was calling .hide() instead of .toggle(), so popover would never show.

Fixes #1514