### PR TITLE
fix(typeahead): reposition results on update

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -290,9 +290,12 @@ describe('typeahead', function () {
     });
 
     describe('placement', function () {
-      var $$rAF;
-      beforeEach(inject(function (_$$rAF_) {
-        $$rAF = _$$rAF_
+      var $$rAF,
+          $timeout;
+      
+      beforeEach(inject(function (_$$rAF_, _$timeout_) {
+        $$rAF = _$$rAF_;
+        $timeout = _$timeout_;
       }));
 
       it('should default to `top` placement', function() {
@@ -316,6 +319,41 @@ describe('typeahead', function () {
         expect(sandboxEl.children('.dropdown-menu').hasClass('bottom-right')).toBeTruthy();
       });
 
+      it('should re-apply placement when the results change', function () {
+        var typeahead = $typeahead($('<input>'), null, { placement: 'top' });
+        spyOn(typeahead, '$applyPlacement');
+        typeahead.update([]);
+
+        $timeout.flush();
+        expect(typeahead.$applyPlacement).toHaveBeenCalled();
+      });
+      
+      it('should not re-apply placement when the results change if the placement is bottom', function () {
+        var typeahead = $typeahead($('<input>'), null, { placement: 'bottom' });
+        spyOn(typeahead, '$applyPlacement');
+        typeahead.update([]);
+
+        $timeout.flush();
+        expect(typeahead.$applyPlacement).not.toHaveBeenCalled();
+      });
+      
+      it('should not re-apply placement when the results change if the placement is bottom-left', function () {
+        var typeahead = $typeahead($('<input>'), null, { placement: 'bottom-left' });
+        spyOn(typeahead, '$applyPlacement');
+        typeahead.update([]);
+
+        $timeout.flush();
+        expect(typeahead.$applyPlacement).not.toHaveBeenCalled();
+      });
+      
+      it('should not re-apply placement when the results change if the placement is bottom-right', function () {
+        var typeahead = $typeahead($('<input>'), null, { placement: 'bottom-right' });
+        spyOn(typeahead, '$applyPlacement');
+        typeahead.update([]);
+
+        $timeout.flush();
+        expect(typeahead.$applyPlacement).not.toHaveBeenCalled();
+      });
     });
 
     describe('trigger', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -65,6 +65,14 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           if(scope.$activeIndex >= matches.length) {
             scope.$activeIndex = 0;
           }
+          
+          // When the placement is not one of the bottom placements, re-calc the positioning
+          // so the results render correctly.
+          if (/^(bottom|bottom-left|bottom-right)$/.test(options.placement)) return;
+          
+          // wrap in a $timeout so the results are updated
+          // before repositioning
+          $timeout($typeahead.$applyPlacement);
         };
 
         $typeahead.activate = function(index) {


### PR DESCRIPTION
When the placement is not one of the bottom placements, the typeahead is positioning the results incorrectly.

Calling the $applyPlacement function inside the typeahead's update function, will cause the results to position correctly as the suggestions are updated.  This fixes issue https://github.com/mgcrea/angular-strap/issues/1480