### PR TITLE
feat(typeahead) New option disableAutoSelect

### DIFF
--- a/src/typeahead/docs/typeahead.demo.html
+++ b/src/typeahead/docs/typeahead.demo.html
@@ -32,7 +32,7 @@ $scope.selectedAddress = "{{selectedAddress}}";
       </div>
       <div class="form-group">
         <label>Icon</label>
-        <input type="text" class="form-control" ng-model="selectedIcon" data-min-length="0" data-html="1" data-disable-auto-select="true" data-animation="am-flip-x" ng-options="icon as icon.label for icon in icons" placeholder="Enter icon" bs-typeahead>
+        <input type="text" class="form-control" ng-model="selectedIcon" data-min-length="0" data-html="1" data-auto-select="true" data-animation="am-flip-x" ng-options="icon as icon.label for icon in icons" placeholder="Enter icon" bs-typeahead>
       </div>
       <hr>
       <!-- Using an async data provider -->
@@ -149,7 +149,7 @@ $scope.selectedAddress = "{{selectedAddress}}";
           </td>
         </tr>
         <tr>
-          <td>disableAutoSelect</td>
+          <td>autoSelect</td>
           <td>boolean</td>
           <td>false</td>
           <td>

--- a/src/typeahead/docs/typeahead.demo.html
+++ b/src/typeahead/docs/typeahead.demo.html
@@ -32,7 +32,7 @@ $scope.selectedAddress = "{{selectedAddress}}";
       </div>
       <div class="form-group">
         <label>Icon</label>
-        <input type="text" class="form-control" ng-model="selectedIcon" data-min-length="0" data-html="1" data-animation="am-flip-x" ng-options="icon as icon.label for icon in icons" placeholder="Enter icon" bs-typeahead>
+        <input type="text" class="form-control" ng-model="selectedIcon" data-min-length="0" data-html="1" data-disable-auto-select="true" data-animation="am-flip-x" ng-options="icon as icon.label for icon in icons" placeholder="Enter icon" bs-typeahead>
       </div>
       <hr>
       <!-- Using an async data provider -->
@@ -146,6 +146,14 @@ $scope.selectedAddress = "{{selectedAddress}}";
           <td>1</td>
           <td>
             <p>The minimum character length needed before triggering autocomplete suggestions.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>disableAutoSelect</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Whether or not the first match will automatically be selected upon typing.</p>
           </td>
         </tr>
         <tr>

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -83,6 +83,10 @@ describe('typeahead', function () {
     },
     'options-minLength': {
       element: '<input type="text" ng-model="selectedState" data-min-length="0" ng-options="state for state in states" bs-typeahead>'
+    },
+    'options-disableAutoSelect': {
+      scope: {states: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming']},
+      element: '<input type="text" ng-model="selectedState" data-min-length="0" data-disable-auto-select="1" ng-options="state for state in states" bs-typeahead>'
     }
   };
 
@@ -432,6 +436,22 @@ describe('typeahead', function () {
       scope.$digest();
       expect(sandboxEl.find('.dropdown-menu li').length).toBe($typeahead.defaults.limit);
       expect(scope.$$childHead.$isVisible()).toBeTruthy();
+    });
+
+  });
+
+  describe('disableAutoSelect', function() {
+
+    it('should not auto-select the first match upon meeting minLength', function() {
+      var elm = compileDirective('options-disableAutoSelect', {});
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.dropdown-menu li').hasClass('active')).not.toBeTruthy();
+    });
+
+    it('should auto-select the first match upon meeting minLength', function() {
+      var elm = compileDirective('options-minLength', {});
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.dropdown-menu li').hasClass('active')).toBeTruthy();
     });
 
   });

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -84,9 +84,9 @@ describe('typeahead', function () {
     'options-minLength': {
       element: '<input type="text" ng-model="selectedState" data-min-length="0" ng-options="state for state in states" bs-typeahead>'
     },
-    'options-disableAutoSelect': {
+    'options-autoSelect': {
       scope: {states: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Dakota', 'North Carolina', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming']},
-      element: '<input type="text" ng-model="selectedState" data-min-length="0" data-disable-auto-select="1" ng-options="state for state in states" bs-typeahead>'
+      element: '<input type="text" ng-model="selectedState" data-min-length="0" data-auto-select="1" ng-options="state for state in states" bs-typeahead>'
     }
   };
 
@@ -440,16 +440,16 @@ describe('typeahead', function () {
 
   });
 
-  describe('disableAutoSelect', function() {
+  describe('autoSelect', function() {
 
     it('should not auto-select the first match upon meeting minLength', function() {
-      var elm = compileDirective('options-disableAutoSelect', {});
+      var elm = compileDirective('options-minLength', {});
       angular.element(elm[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu li').hasClass('active')).not.toBeTruthy();
     });
 
     it('should auto-select the first match upon meeting minLength', function() {
-      var elm = compileDirective('options-minLength', {});
+      var elm = compileDirective('options-autoSelect', {});
       angular.element(elm[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu li').hasClass('active')).toBeTruthy();
     });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -18,6 +18,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
       minLength: 1,
       filter: 'filter',
       limit: 6,
+      disableAutoSelect: false,
       comparator: ''
     };
 
@@ -38,7 +39,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         scope.$resetMatches = function(){
           scope.$matches = [];
-          scope.$activeIndex = 0;
+          scope.$activeIndex = options.disableAutoSelect ? -1 : 0; // If set to 0, the first match will be highlighted
         };
         scope.$resetMatches();
 
@@ -63,7 +64,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         $typeahead.update = function(matches) {
           scope.$matches = matches;
           if(scope.$activeIndex >= matches.length) {
-            scope.$activeIndex = 0;
+            scope.$activeIndex = options.disableAutoSelect ? -1 : 0;
           }
           
           // When the placement is not one of the bottom placements, re-calc the positioning
@@ -158,6 +159,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           if(options.keyboard) {
             element.off('keydown', $typeahead.$onKeyDown);
           }
+          if( options.disableAutoSelect )
+            $typeahead.activate(-1);
           hide();
         };
 
@@ -183,7 +186,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'comparator', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'disableAutoSelect', 'comparator', 'id'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -18,7 +18,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
       minLength: 1,
       filter: 'filter',
       limit: 6,
-      disableAutoSelect: false,
+      autoSelect: false,
       comparator: ''
     };
 
@@ -39,7 +39,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         scope.$resetMatches = function(){
           scope.$matches = [];
-          scope.$activeIndex = options.disableAutoSelect ? -1 : 0; // If set to 0, the first match will be highlighted
+          scope.$activeIndex = options.autoSelect ? 0 : -1; // If set to 0, the first match will be highlighted
         };
         scope.$resetMatches();
 
@@ -64,7 +64,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         $typeahead.update = function(matches) {
           scope.$matches = matches;
           if(scope.$activeIndex >= matches.length) {
-            scope.$activeIndex = options.disableAutoSelect ? -1 : 0;
+            scope.$activeIndex = options.autoSelect ? 0: -1;
           }
           
           // When the placement is not one of the bottom placements, re-calc the positioning
@@ -159,7 +159,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           if(options.keyboard) {
             element.off('keydown', $typeahead.$onKeyDown);
           }
-          if( options.disableAutoSelect )
+          if(!options.autoSelect)
             $typeahead.activate(-1);
           hide();
         };
@@ -186,7 +186,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'disableAutoSelect', 'comparator', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'autoSelect', 'comparator', 'id'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
Allow override of the default behaviour of auto-selecting the first match. Non-breaking to prior behaviour.

Fixes #1300