### PR TITLE
fix(datepicker): remove table-layout css from template

### DIFF
--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -1,5 +1,5 @@
 <div class="dropdown-menu datepicker" ng-class="'datepicker-mode-' + $mode" style="max-width: 320px;">
-<table style="table-layout: fixed; height: 100%; width: 100%;">
+<table style="height: 100%; width: 100%;">
   <thead>
     <tr class="text-center">
       <th>


### PR DESCRIPTION
table-layout="fixed" is causing rendering issues in IE11 when changing from month/day view to year/month view.

The styling is unnecessary because the table's width is set to 100%.  Fixes #1506