### PR TITLE
[Docs] Use en-dash instead of hyphen in license between years

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Please submit all pull requests the against master branch. If your pull request 
 
 	The MIT License
 
-	Copyright (c) 2012 - 2014 Olivier Louvignes
+	Copyright (c) 2012 – 2014 Olivier Louvignes
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
docs

English grammar states that an en-dash should be used, not a hyphen between two years.

## Examples of each
__em-dash__: —
__en-dash__: –
__hyphen__: -

## Em-dash
An em-dash is typically used as a stand-in for a comma or parenthesis to separate out phrases—or even just a word—in a sentence for various reasons (i.e. an appositive). Examples where an em-dash should be used:

* School is based on the three R’s—reading, writing, and ’rithmetic.
* Against all odds, Pete—the unluckiest man alive—won the lottery.
* I sense something; a presence I've not felt since—

## En-dash
An en-dash is used to connect values in a range or that are related. A good rule is to use it when you're expressing a "to" relationship. Examples where an en-dash should be used:

* in years 1939–1945
* pages 31–32 may be relevant
* New York beat Los Angeles 98–95
* When American English would use an em-dash – following British and Canadian conventions.

## Hyphen
A hyphen is used to join words in a compound construction, or separate syllables of a word, like during a line break, or (self-evidently) a hyphenated name.

* pro-American
* cruelty-free eggs
* em-dash
* it's pronounced hos-pi-tal-it-tee
* Olivia Newton-John