### PR TITLE
fix(select): Does not gain selection until up/down key pressed

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -48,7 +48,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         var scope = $select.$scope;
 
         scope.$matches = [];
-        scope.$activeIndex = 0;
+        scope.$activeIndex = -1;
         scope.$isMultiple = options.multiple;
         scope.$showAllNoneButtons = options.allNoneButtons && options.multiple;
         scope.$iconCheckmark = options.iconCheckmark;
@@ -197,6 +197,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
           if (!options.multiple) {
             // Navigate with keyboard
             if(evt.keyCode === 38 && scope.$activeIndex > 0) scope.$activeIndex--;
+            else if(evt.keyCode === 38 && scope.$activeIndex < 0) scope.$activeIndex = scope.$matches.length - 1;
             else if(evt.keyCode === 40 && scope.$activeIndex < scope.$matches.length - 1) scope.$activeIndex++;
             else if(angular.isUndefined(scope.$activeIndex)) scope.$activeIndex = 0;
             scope.$digest();
@@ -223,6 +224,9 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         var _hide = $select.hide;
         $select.hide = function() {
+          if(!options.multiple && !controller.$modelValue) {
+            scope.$activeIndex = -1;
+          } 
           $select.$element.off(isTouch ? 'touchstart' : 'mousedown', $select.$onMouseDown);
           if(options.keyboard) {
             element.off('keydown', $select.$onKeyDown);

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -2,17 +2,18 @@
 
 describe('select', function () {
 
-  var $compile, $templateCache, $select, scope, sandboxEl;
+  var $compile, $templateCache, $select, scope, sandboxEl, $timeout;
 
   beforeEach(module('ngSanitize'));
   beforeEach(module('mgcrea.ngStrap.select'));
 
-  beforeEach(inject(function (_$rootScope_, _$compile_, _$templateCache_, _$select_) {
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$templateCache_, _$select_, _$timeout_) {
     scope = _$rootScope_.$new();
     sandboxEl = $('<div>').attr('id', 'sandbox').appendTo($('body'));
     $compile = _$compile_;
     $templateCache = _$templateCache_;
     $select = _$select_;
+    $timeout = _$timeout_;
   }));
 
   afterEach(function() {
@@ -103,6 +104,12 @@ describe('select', function () {
     return jQuery(element[0]);
   }
 
+  function triggerKeyDown(elm, keyCode) {
+    var evt = $.Event('keydown');
+    evt.which = evt.keyCode = keyCode;
+    angular.element(elm[0]).triggerHandler(evt);
+  }
+
   // Tests
 
   describe('with default template', function () {
@@ -150,6 +157,28 @@ describe('select', function () {
       angular.element(elm.next('button')[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu li').length).toBe(scope.icons.length);
       expect(sandboxEl.find('.dropdown-menu li:eq(0)').text().trim()).toBe(scope.icons[0].label);
+    });
+
+  });
+
+  describe('when model has no initial selection', function() {
+
+    it('should not have any selection upon open until down key', function() {
+      var elm = compileDirective('default');
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.active').length).toBe(0);
+      $timeout.flush();
+      triggerKeyDown( elm, 40 );
+      expect(sandboxEl.find('.active').length).toBe(1);
+    });
+
+    it('should not have any selection upon open until up key', function() {
+      var elm = compileDirective('default');
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.active').length).toBe(0);
+      $timeout.flush();
+      triggerKeyDown( elm, 38 );
+      expect(sandboxEl.find('.active').length).toBe(1);
     });
 
   });


### PR DESCRIPTION
The prior behavior was that the first option was automatically matched upon focus. This patch removes that auto matching, and instead we allow the user to initiate the first match by either pressing the up arrow key or the down arrow keys (in addition to clicking).

Fixes #1443