### PR TITLE
Reset view to default if model date changes

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -84,6 +84,9 @@ angular.module('mgcrea.ngStrap.datepicker', [
           if(angular.isDate(date) && !isNaN(date.getTime())) {
             $datepicker.$date = date;
             $picker.update.call($picker, date);
+          } else {
+            $datepicker.$date = date;
+            $datepicker.setMode(options.startView);
           }
           // Build only if pristine
           $datepicker.$build(true);


### PR DESCRIPTION
I'm using datepicker for functionality where users use a shared physical device for creating user accounts: datepicker is used for entering persons birthday. Problem is: when $scope.bday resets, datepicker selection window still has the previous bday active (and hence visible for next person - bad).

With this commit date picker view is selected to default, and $scope.$date is being reset. 

Tests pass. There was no references for testing e.g. $scope.$mode, so left tests untouched for now.
