### PR TITLE
Add support for prefixEvent on bsModal

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -300,7 +300,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'animation', 'id'], function(key) {
+        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'animation', 'prefixEvent', 'id'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -66,6 +66,9 @@ describe('modal', function() {
     'options-template': {
       scope: {modal: {title: 'Title', content: 'Hello Modal!', counter: 0}, items: ['foo', 'bar', 'baz']},
       element: '<a title="{{modal.title}}" data-content="{{modal.content}}" data-template="custom" bs-modal>click me</a>'
+    },
+    'options-prefix-event': {
+      element: '<a data-prefix-event="customprefix" bs-modal="modal">click me</a>'
     }
   };
 
@@ -310,6 +313,18 @@ describe('modal', function() {
       angular.element(elm[0]).triggerHandler('click');
       scope.$digest();
       expect(id).toBe('modal1');
+    });
+
+    it('should allow setting custom event prefix', function() {
+      var elm = compileDirective('options-prefix-event');
+      var eventTriggered = false;
+      scope.$on('customprefix.show.before', function(evt, modal) {
+        eventTriggered = true;
+      });
+
+      angular.element(elm[0]).triggerHandler('click');
+      scope.$digest();
+      expect(eventTriggered).toBe(true);
     });
 
   });


### PR DESCRIPTION
prefixEvent was not a recognized option for bsModal.  Added it to list
of options, together with unit tests to make sure it works.

Closes #1559