### PR TITLE
Don't stop event if no option is selected.

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -66,11 +66,11 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           if(scope.$activeIndex >= matches.length) {
             scope.$activeIndex = options.autoSelect ? 0: -1;
           }
-          
+
           // When the placement is not one of the bottom placements, re-calc the positioning
           // so the results render correctly.
           if (/^(bottom|bottom-left|bottom-right)$/.test(options.placement)) return;
-          
+
           // wrap in a $timeout so the results are updated
           // before repositioning
           $timeout($typeahead.$applyPlacement);
@@ -81,6 +81,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         };
 
         $typeahead.select = function(index) {
+          if(index === -1) return;
           var value = scope.$matches[index].value;
           // console.log('$setViewValue', value);
           controller.$setViewValue(value);
@@ -120,8 +121,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         $typeahead.$onKeyDown = function(evt) {
           if(!/(38|40|13)/.test(evt.keyCode)) return;
 
-          // Let ngSubmit pass if the typeahead tip is hidden
-          if($typeahead.$isVisible()) {
+          // Let ngSubmit pass if the typeahead tip is hidden or no option is selected
+          if($typeahead.$isVisible() && !(evt.keyCode === 13 && scope.$activeIndex === -1)) {
             evt.preventDefault();
             evt.stopPropagation();
           }
@@ -192,7 +193,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Disable browser autocompletion
         element.attr('autocomplete' ,'off');
-        
+
         // Build proper bsOptions
         var filter = options.filter || defaults.filter;
         var limit = options.limit || defaults.limit;


### PR DESCRIPTION
This fixes #1575, which I reported.

New behaviour: when enter is pressed with the typeahead dropdown open but no option selected (because autoSelect is set to false), the situation is handled same as if the dropdown wasn't open.