### PR TITLE
add backdropAnimation to list of options

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -300,7 +300,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'animation', 'id'], function(key) {
+        angular.forEach(['template', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
this is to fix the same bug that appeared in `tooltip`, but in this case for modal.js 4f27655