### PR TITLE
fix(typeahead): position the tooltip correctly even when it is not yet visible

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -94,6 +94,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         // Protected methods
 
         $typeahead.$isVisible = function() {
+          // if it hasn't been positioned yet, it needs to be visible so that positioning happens correctly
+          if($typeahead.$element.css('top')=='-9999px' && $typeahead.$element.css('left')=='-9999px') return true;
           if(!options.minLength || !controller) {
             return !!scope.$matches.length;
           }


### PR DESCRIPTION
set the typeahead tooltip to force itself to be visible until it has been positioned, so that positioning will happen properly

closes issue 1588
