### PR TITLE
Exposing enter and leave as tooltip scope methods.

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -76,6 +76,16 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
             $tooltip.show();
           });
         };
+        scope.$leave = function() {
+          scope.$$postDigest(function() {
+            $tooltip.leave();
+          });
+        };
+        scope.$enter = function() {
+          scope.$$postDigest(function() {
+            $tooltip.enter();
+          });
+        };
         scope.$toggle = function() {
           scope.$$postDigest(function() {
             $tooltip.toggle();


### PR DESCRIPTION
This allows the template to easily override the timeout, for cases where you'd like the tooltip to persist when hovering over the tooltip itself.