### PR TITLE
feat($timepicker): add support for seconds

### DIFF
--- a/src/helpers/date-formatter.js
+++ b/src/helpers/date-formatter.js
@@ -24,7 +24,7 @@ angular.module('mgcrea.ngStrap.helpers.dateFormatter', [])
     };
 
     function splitTimeFormat(format) {
-      return /(h+)([:\.])?(m+)[ ]?(a?)/i.exec(format).slice(1);
+      return /(h+)([:\.])?(m+)([:\.])?(s*)[ ]?(a?)/i.exec(format).slice(1);
     }
 
     // h:mm a => h
@@ -37,14 +37,24 @@ angular.module('mgcrea.ngStrap.helpers.dateFormatter', [])
       return splitTimeFormat(timeFormat)[2];
     };
 
+    // h:mm:ss a => ss
+    this.secondsFormat = function(timeFormat) {
+      return splitTimeFormat(timeFormat)[4];
+    };
+
     // h:mm a => :
     this.timeSeparator = function(timeFormat) {
       return splitTimeFormat(timeFormat)[1];
     };
 
+    // h:mm:ss a => true, h:mm a => false
+    this.showSeconds = function(timeFormat) {
+      return !!splitTimeFormat(timeFormat)[4];
+    };
+
     // h:mm a => true, H.mm => false
     this.showAM = function(timeFormat) {
-      return !!splitTimeFormat(timeFormat)[3];
+      return !!splitTimeFormat(timeFormat)[5];
     };
 
     this.formatDate = function(date, format, lang, timezone){

--- a/src/timepicker/docs/timepicker.demo.html
+++ b/src/timepicker/docs/timepicker.demo.html
@@ -38,7 +38,8 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
       <!-- Custom example -->
       <div class="form-group" ng-class="{'has-error': timepickerForm.time2.$invalid}">
         <label class="control-label"><i class="fa fa-clock-o"></i> Time <small>(as number)</small></label>
-        <input type="text" class="form-control" size="5" ng-model="selectedTimeAsNumber" data-time-format="HH:mm" data-time-type="number" data-min-time="10:00" data-max-time="13:30" data-autoclose="1" name="time2" bs-timepicker>
+        <input type="text" class="form-control" size="8" ng-model="selectedTimeAsNumber" data-time-format="HH:mm:ss"
+               data-time-type="number" data-min-time="10:00:00" data-max-time="13:30:00" data-autoclose="1" name="time2" bs-timepicker>
       </div>
       <hr>
 
@@ -59,7 +60,7 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
           <input type="text" size="10" class="form-control" ng-model="sharedDate" data-autoclose="1" placeholder="Date" bs-datepicker>
         </div>
         <div class="form-group">
-          <input type="text" size="8" class="form-control" ng-model="sharedDate" data-autoclose="1" placeholder="Time" bs-timepicker>
+          <input type="text" size="8" class="form-control" ng-model="sharedDate" data-time-format="h:mm:ss a" data-autoclose="1" placeholder="Time" bs-timepicker>
         </div>
       </div>
 
@@ -233,6 +234,14 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
           <td>5</td>
           <td>
             <p>Default step for minutes.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>secondStep</td>
+          <td>number</td>
+          <td>5</td>
+          <td>
+            <p>Default step for seconds.</p>
           </td>
         </tr>
         <tr>

--- a/src/timepicker/docs/timepicker.demo.js
+++ b/src/timepicker/docs/timepicker.demo.js
@@ -3,8 +3,8 @@
 angular.module('mgcrea.ngStrapDocs')
 
 .controller('TimepickerDemoCtrl', function($scope, $http) {
-  $scope.time = new Date(1970, 0, 1, 10, 30);
-  $scope.selectedTimeAsNumber = 10 * 36e5;
+  $scope.time = new Date(1970, 0, 1, 10, 30, 40);
+  $scope.selectedTimeAsNumber = 10 * 36e5 + 30 * 6e4 + 40 * 1e3;
   $scope.selectedTimeAsString = '10:00';
-  $scope.sharedDate = new Date(new Date().setMinutes(0));
+  $scope.sharedDate = new Date(new Date().setMinutes(0, 0));
 });

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -38,18 +38,18 @@ describe('timepicker', function() {
       element: '<input id="timepicker1" type="text" ng-model="selectedTime" bs-timepicker>'
     },
     'value-past': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30)},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42)},
       element: '<input type="text" ng-model="selectedTime" bs-timepicker>'
     },
     'markup-ngRepeat': {
       element: '<ul><li ng-repeat="i in [1, 2, 3]"><input type="text" ng-model="selectedTime" bs-timepicker></li></ul>'
     },
     'markup-ngChange': {
-      scope: {selectedDate: new Date(1970, 0, 1, 10, 30), onChange: function() {}},
+      scope: {selectedDate: new Date(1970, 0, 1, 10, 30, 42), onChange: function() {}},
       element: '<input type="text" ng-model="selectedTime" ng-change="onChange()" bs-timepicker>'
     },
     'markup-ngRequired': {
-      scope: {selectedTime: new Date(2012, 5, 15, 9, 30)},
+      scope: {selectedTime: new Date(2012, 5, 15, 9, 30, 42)},
       element: '<input type="text" ng-model="selectedTime" ng-required="true" bs-timepicker>'
     },
     'options-animation': {
@@ -68,8 +68,16 @@ describe('timepicker', function() {
       element: '<input type="text" data-template="custom" ng-model="selectedTime" bs-timepicker>'
     },
     'options-timeFormat': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30)},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42)},
       element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm" bs-timepicker>'
+    },
+    'options-timeFormat-seconds': {
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42)},
+      element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm:ss" bs-timepicker>'
+    },
+    'options-timeFormat-seconds-meridian': {
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42)},
+      element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm:ss a" bs-timepicker>'
     },
     'options-timezone-utc': {
       element: '<input type="text" ng-model="selectedTime" data-time-format="HH:mm" data-timezone="UTC" bs-timepicker>'
@@ -83,19 +91,19 @@ describe('timepicker', function() {
       element: '<input type="text" ng-model="selectedTime" data-time-type="string" data-time-format="HH:mm" bs-timepicker>'
     },
     'options-timeType-number': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30).getTime()},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42).getTime()},
       element: '<input type="text" ng-model="selectedTime" data-time-type="number" data-time-format="HH:mm" bs-timepicker>'
     },
     'options-timeType-unix': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30) / 1000},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42) / 1000},
       element: '<input type="text" ng-model="selectedTime" data-time-type="unix" data-time-format="HH:mm" bs-timepicker>'
     },
     'options-timeType-iso': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30).toISOString()},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42).toISOString()},
       element: '<input type="text" ng-model="selectedTime" data-time-type="iso" data-time-format="HH:mm" bs-timepicker>'
     },
     'options-minTime': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30), minTime: '09:30 AM'},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 0), minTime: '09:30 AM'},
       element: '<input type="text" ng-model="selectedTime" data-min-time="{{minTime}}" bs-timepicker>'
     },
     'options-minTime-now': {
@@ -107,7 +115,7 @@ describe('timepicker', function() {
       element: '<input type="text" ng-model="selectedTime" data-max-time="now" bs-timepicker>'
     },
     'options-maxTime': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30), maxTime: '10:30 PM'},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 0), maxTime: '10:30 PM'},
       element: '<input type="text" ng-model="selectedTime" data-max-time="{{maxTime}}" bs-timepicker>'
     },
     'options-autoclose': {
@@ -117,15 +125,18 @@ describe('timepicker', function() {
       element: '<input type="text" ng-model="selectedTime" data-use-native="1" bs-timepicker>'
     },
     'options-modelTimeFormat': {
-      scope: {selectedTime: '12:20:00'},
+      scope: {selectedTime: '12:20:10'},
       element: '<input type="text" ng-model="selectedTime" data-time-type="string" data-model-time-format="HH:mm:ss" data-time-format="HH:mm" bs-timepicker>'
     },
     'options-arrowBehavior': {
-      scope: {selectedTime: new Date(1970, 0, 1, 10, 30), arrowBehavior: 'pager'},
+      scope: {selectedTime: new Date(1970, 0, 1, 10, 30, 42), arrowBehavior: 'pager'},
       element: '<input type="text" ng-model="selectedTime" length="5" data-arrow-behavior="{{ arrowBehavior }}" bs-timepicker>'
     },
     'options-roundDisplay': {
       element: '<input type="text" data-minute-step="15" ng-model="selectedTime" data-round-display="true" bs-timepicker>'
+    },
+    'options-roundDisplay-seconds': {
+      element: '<input type="text" data-minute-step="15" data-second-step="20" ng-model="selectedTime" data-round-display="true" data-time-format="HH:mm:ss" bs-timepicker>'
     },
     'bsShow-attr': {
       scope: {selectedTime: new Date()},
@@ -183,7 +194,7 @@ describe('timepicker', function() {
       angular.element(elm[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'h'));
       expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'mm'));
-      expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'a'));
+      expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(6) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'a'));
     });
 
     it('should correctly update the model when the view is updated', function() {
@@ -199,7 +210,7 @@ describe('timepicker', function() {
       expect(scope.selectedTime.toISOString().substr(0, 10)).toBe('1970-01-01');
       angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(11)')).triggerHandler('click');
       expect(elm.val()).toBe('11:30 AM');
-      expect(scope.selectedTime).toEqual(new Date(1970, 0, 1, 11, 30));
+      expect(scope.selectedTime).toEqual(new Date(1970, 0, 1, 11, 30, 42));
       expect(scope.selectedTime.toISOString().substr(0, 10)).toBe('1970-01-01');
     });
 
@@ -239,7 +250,7 @@ describe('timepicker', function() {
       var elm = compileDirective('default', {selectedTime: undefined});
       expect(elm.val()).toBe('');
       angular.element(elm[0]).triggerHandler('focus');
-      var amButton = angular.element(sandboxEl.find('.dropdown-menu tbody td:eq(4) button:eq(0)')[0]);
+      var amButton = angular.element(sandboxEl.find('.dropdown-menu tbody td:eq(6) button:eq(0)')[0]);
       spyOn(scope.$$childHead, '$switchMeridian');
       amButton.triggerHandler('click');
       // expect not to throw exception
@@ -283,12 +294,12 @@ describe('timepicker', function() {
 
       expect(elm.val()).toBe('9:30 AM');
       expect(scope.selectedTime).toBeDefined();
-      expect(scope.selectedTime).toEqual(new Date(2012, 5, 15, 9, 30));
+      expect(scope.selectedTime).toEqual(new Date(2012, 5, 15, 9, 30, 42));
 
       angular.element(elm[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'h'));
       expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'mm'));
-      expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'a'));
+      expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(6) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'a'));
 
     });
 
@@ -615,10 +626,30 @@ describe('timepicker', function() {
 
     });
 
+    describe('seconds display', function() {
+
+      it('should hide seconds', function() {
+        var elm = compileDirective('options-timeFormat');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu thead .btn').length).toBe(2);
+        expect(sandboxEl.find('.dropdown-menu tbody .btn').length).toBe($timepicker.defaults.length * 2);
+        expect(sandboxEl.find('.dropdown-menu tfoot .btn').length).toBe(2);
+      });
+
+      it('should show seconds', function() {
+        var elm = compileDirective('options-timeFormat-seconds');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu thead .btn').length).toBe(3);
+        expect(sandboxEl.find('.dropdown-menu tbody .btn').length).toBe($timepicker.defaults.length * 3);
+        expect(sandboxEl.find('.dropdown-menu tfoot .btn').length).toBe(3);
+      });
+
+    });
+
     describe('keyboard', function() {
 
       it('should support keyboard navigation', function() {
-        var elm = compileDirective('default', { selectedTime: new Date(2014, 10, 23, 8, 30) });
+        var elm = compileDirective('default', { selectedTime: new Date(2014, 10, 23, 8, 30, 40) });
         expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
         angular.element(elm[0]).triggerHandler('focus');
         // need to flush timeout to register keyboard events
@@ -647,12 +678,37 @@ describe('timepicker', function() {
         expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2) .btn-primary').text()).toBe('30');
       });
 
+      it('should support keyboard navigation with seconds', function() {
+        var elm = compileDirective('options-timeFormat-seconds', { selectedTime: new Date(2014, 10, 23, 8, 30, 40) });
+        expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
+        angular.element(elm[0]).triggerHandler('focus');
+        // need to flush timeout to register keyboard events
+        // IMPORTANT: do it before $animate.triggerCallbacks, because
+        // on 1.3 that seems to do both and we get an error in 1.2
+        $timeout.flush();
+        $animate.triggerCallbacks();
+        expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(1);
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe('08');
+
+        // cursor right -> select minutes
+        triggerKeyDown(elm, 39);
+        // cursor right -> select seconds
+        triggerKeyDown(elm, 39);
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe('40');
+        // cursor up
+        triggerKeyDown(elm, 38);
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe('35');
+        // cursor down
+        triggerKeyDown(elm, 40);
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe('40');
+      });
+
       function getSelection(element) {
         return { start: element[0].selectionStart, end: element[0].selectionEnd};
       }
 
       it('should select date part when using keyboard navigation', function() {
-        var elm = compileDirective('default', { selectedTime: new Date(2014, 10, 23, 8, 30) });
+        var elm = compileDirective('default', { selectedTime: new Date(2014, 10, 23, 8, 30, 40) });
         expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
         angular.element(elm[0]).triggerHandler('focus');
         // need to flush timeout to register keyboard events
@@ -690,6 +746,41 @@ describe('timepicker', function() {
         expect(selection.end).toBe(4);
       });
 
+      it('should select date part when using keyboard navigation with seconds', function() {
+        var elm = compileDirective('default', { selectedTime: new Date(2014, 10, 23, 8, 30, 40) });
+        expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(0);
+        angular.element(elm[0]).triggerHandler('focus');
+        // need to flush timeout to register keyboard events
+        // IMPORTANT: do it before $animate.triggerCallbacks, because
+        // on 1.3 that seems to do both and we get an error in 1.2
+        $timeout.flush();
+        $animate.triggerCallbacks();
+        expect(sandboxEl.children('.dropdown-menu.timepicker').length).toBe(1);
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe('8');
+
+        // cursor down -> select hours
+        triggerKeyDown(elm, 40);
+
+        // cursor right -> select minutes
+        triggerKeyDown(elm, 39);
+
+        // cursor right -> select seconds
+        triggerKeyDown(elm, 39);
+        selection = getSelection(elm);
+        expect(selection.start).toBe(5);
+        expect(selection.end).toBe(7);
+        // cursor up -> select seconds
+        triggerKeyDown(elm, 38);
+        expect(selection.start).toBe(5);
+        expect(selection.end).toBe(7);
+
+        // cursor right -> select hours
+        triggerKeyDown(elm, 39);
+        var selection = getSelection(elm);
+        expect(selection.start).toBe(0);
+        expect(selection.end).toBe(1);
+      });
+
     });
 
     describe('timeFormat', function() {
@@ -700,6 +791,23 @@ describe('timepicker', function() {
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(09)')).triggerHandler('click');
         expect(elm.val()).toBe('09:30');
+      });
+
+      it('should correctly display time with seconds and meridian', function() {
+        var elm = compileDirective('options-timeFormat-seconds-meridian');
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'h'));
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'mm'));
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'ss'));
+        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(6) .btn-primary').text()).toBe(dateFilter(scope.selectedTime, 'a'));
+      });
+
+      it('should support a custom timeFormat with seconds', function() {
+        var elm = compileDirective('options-timeFormat-seconds');
+        expect(elm.val()).toBe('10:30:42');
+        angular.element(elm[0]).triggerHandler('focus');
+        angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(47)')).triggerHandler('click');
+        expect(elm.val()).toBe('10:30:47');
       });
 
     });
@@ -756,32 +864,32 @@ describe('timepicker', function() {
       it('should support a number timeType', function() {
         var elm = compileDirective('options-timeType-number');
         expect(elm.val()).toBe('10:30');
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30).getTime());
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30, 42).getTime());
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(09)')).triggerHandler('click');
         expect(elm.val()).toBe('09:30');
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30).getTime());
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30, 42).getTime());
       });
 
       it('should support a unix timeType', function() {
         var elm = compileDirective('options-timeType-unix');
         expect(elm.val()).toBe('10:30');
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30).getTime() / 1000);
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30, 42).getTime() / 1000);
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(09)')).triggerHandler('click');
         expect(elm.val()).toBe('09:30');
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30) / 1000);
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30, 42) / 1000);
       });
 
       it('should support a iso timeType', function() {
         var elm = compileDirective('options-timeType-iso');
         var date = new Date(1970, 0, 1, 10, 30);
         expect(elm.val()).toBe(date.getHours() + ':' + date.getMinutes());
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30).toISOString());
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 10, 30, 42).toISOString());
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(09)')).triggerHandler('click');
         expect(elm.val()).toBe('09:30');
-        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30).toISOString());
+        expect(scope.selectedTime).toBe(new Date(1970, 0, 1, 9, 30, 42).toISOString());
       });
 
     });
@@ -861,7 +969,7 @@ describe('timepicker', function() {
       });
 
       it('should ignore date part of ngModel when validating with minTime', function() {
-        var elm = compileDirective('options-minTime', { selectedTime: new Date(1957, 6, 13, 10, 30)});
+        var elm = compileDirective('options-minTime', { selectedTime: new Date(1957, 6, 13, 10, 30, 42)});
         angular.element(elm[0]).triggerHandler('change');
         expect(elm.hasClass('ng-valid-min')).toBeTruthy();
       });
@@ -974,13 +1082,13 @@ describe('timepicker', function() {
         angular.element(elm[0]).triggerHandler('focus');
         angular.element(sandboxEl.find('.dropdown-menu tbody .btn:contains(13)')).triggerHandler('click');
         expect(elm.val()).toBe('13:20');
-        expect(scope.selectedTime).toBe('13:20:00');
+        expect(scope.selectedTime).toBe('13:20:10');
 
         // Should correctly set the model if the date is manually typed into the input
         elm.val('10:00');
         angular.element(elm[0]).triggerHandler('change');
         scope.$digest();
-        expect(scope.selectedTime).toBe('10:00:00');
+        expect(scope.selectedTime).toBe('10:00:10');
 
       });
 
@@ -1017,13 +1125,44 @@ describe('timepicker', function() {
 
     describe('roundDisplay', function() {
 
-      it('should floor display minutes to nearest minuteStep interval when ngModel value is undefined', function() {
-        var elm = compileDirective('options-roundDisplay', { selectedTime: undefined });
-        var currentTime = new Date();
-        currentTime.setMinutes(currentTime.getMinutes() - currentTime.getMinutes() % 15);
-        angular.element(elm[0]).triggerHandler('focus');
-        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0)').text()).toBe(dateFilter(currentTime, 'h'));
-        expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2)').text()).toBe(dateFilter(currentTime, 'mm'));
+      var currentTime, i = 0;
+      var times = [
+        new Date(1970, 6, 13, 10, 33, 42),
+        new Date(1970, 6, 13, 10, 33, 0),
+        new Date(1970, 6, 13, 10, 0, 59),
+        new Date(1970, 6, 13, 10, 0, 0),
+        new Date(1970, 6, 13),
+        new Date(1970, 6, 13, 23, 59, 59)
+      ];
+
+      beforeAll(function() { jasmine.clock().install(); });
+      afterAll(function() { jasmine.clock().uninstall(); });
+
+      beforeEach(function() {
+        jasmine.clock().mockDate(times[i]);
+        currentTime = new Date();
+      });
+
+      afterEach(function() { i++; });
+
+      angular.forEach(times, function() {
+        it('should floor display minutes to nearest minuteStep interval when ngModel value is undefined', function() {
+          var elm = compileDirective('options-roundDisplay', { selectedTime: undefined });
+          currentTime.setMinutes(currentTime.getMinutes() - currentTime.getMinutes() % 15);
+          angular.element(elm[0]).triggerHandler('focus');
+          expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0)').text()).toBe(dateFilter(currentTime, 'h'));
+          expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2)').text()).toBe(dateFilter(currentTime, 'mm'));
+        });
+
+        it('should floor display minutes to nearest minuteStep interval when ngModel value is undefined and seconds are shown', function() {
+          var elm = compileDirective('options-roundDisplay-seconds', { selectedTime: undefined });
+          currentTime.setMinutes(currentTime.getMinutes() - currentTime.getMinutes() % 15);
+          currentTime.setSeconds(0);
+          angular.element(elm[0]).triggerHandler('focus');
+          expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(0)').text()).toBe(dateFilter(currentTime, 'HH'));
+          expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(2)').text()).toBe(dateFilter(currentTime, 'mm'));
+          expect(sandboxEl.find('.dropdown-menu tbody tr:eq(2) td:eq(4)').text()).toBe(dateFilter(currentTime, 'ss'));
+        });
       });
 
     });

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -29,6 +29,7 @@ angular.module('mgcrea.ngStrap.timepicker', [
       length: 5,
       hourStep: 1,
       minuteStep: 5,
+      secondStep: 5,
       roundDisplay: false,
       iconUp: 'glyphicon glyphicon-chevron-up',
       iconDown: 'glyphicon glyphicon-chevron-down',
@@ -73,6 +74,8 @@ angular.module('mgcrea.ngStrap.timepicker', [
         var hoursFormat = $dateFormatter.hoursFormat(format),
           timeSeparator = $dateFormatter.timeSeparator(format),
           minutesFormat = $dateFormatter.minutesFormat(format),
+          secondsFormat = $dateFormatter.secondsFormat(format),
+          showSeconds = $dateFormatter.showSeconds(format),
           showAM = $dateFormatter.showAM(format);
 
         scope.$iconUp = options.iconUp;
@@ -109,6 +112,7 @@ angular.module('mgcrea.ngStrap.timepicker', [
           if(!angular.isDate(date)) date = new Date(date);
           if(index === 0) controller.$dateValue.setHours(date.getHours());
           else if(index === 1) controller.$dateValue.setMinutes(date.getMinutes());
+          else if(index === 2) controller.$dateValue.setSeconds(date.getSeconds());
           controller.$setViewValue(angular.copy(controller.$dateValue));
           controller.$render();
           if(options.autoclose && !keep) {
@@ -141,12 +145,22 @@ angular.module('mgcrea.ngStrap.timepicker', [
             minute = new Date(1970, 0, 1, 0, viewDate.minute - (midIndex - i) * options.minuteStep);
             minutes.push({date: minute, label: formatDate(minute, minutesFormat), selected: $timepicker.$date && $timepicker.$isSelected(minute, 1), disabled: $timepicker.$isDisabled(minute, 1)});
           }
+          var seconds = [], second;
+          for(i = 0; i < options.length; i++) {
+            second = new Date(1970, 0, 1, 0, 0, viewDate.second - (midIndex - i) * options.secondStep);
+            seconds.push({date: second, label: formatDate(second, secondsFormat), selected: $timepicker.$date && $timepicker.$isSelected(second, 2), disabled: $timepicker.$isDisabled(second, 2)});
+          }
 
           var rows = [];
           for(i = 0; i < options.length; i++) {
-            rows.push([hours[i], minutes[i]]);
+            if (showSeconds) {
+              rows.push([hours[i], minutes[i], seconds[i]]);
+            } else {
+              rows.push([hours[i], minutes[i]]);
+            }
           }
           scope.rows = rows;
+          scope.showSeconds = showSeconds;
           scope.showAM = showAM;
           scope.isAM = ($timepicker.$date || hours[midIndex].date).getHours() < 12;
           scope.timeSeparator = timeSeparator;
@@ -159,15 +173,19 @@ angular.module('mgcrea.ngStrap.timepicker', [
             return date.getHours() === $timepicker.$date.getHours();
           } else if(index === 1) {
             return date.getMinutes() === $timepicker.$date.getMinutes();
+          } else if(index === 2) {
+            return date.getSeconds() === $timepicker.$date.getSeconds();
           }
         };
 
         $timepicker.$isDisabled = function(date, index) {
           var selectedTime;
           if(index === 0) {
-            selectedTime = date.getTime() + viewDate.minute * 6e4;
+            selectedTime = date.getTime() + viewDate.minute * 6e4 + viewDate.second * 1e3;
           } else if(index === 1) {
-            selectedTime = date.getTime() + viewDate.hour * 36e5;
+            selectedTime = date.getTime() + viewDate.hour * 36e5 + viewDate.second * 1e3;
+          } else if(index === 2) {
+            selectedTime = date.getTime() + viewDate.hour * 36e5 + viewDate.minute * 6e4;
           }
           return selectedTime < options.minTime * 1 || selectedTime > options.maxTime * 1;
         };
@@ -184,11 +202,15 @@ angular.module('mgcrea.ngStrap.timepicker', [
           var newDate = new Date($timepicker.$date);
           var hours = newDate.getHours(), hoursLength = formatDate(newDate, hoursFormat).length;
           var minutes = newDate.getMinutes(), minutesLength = formatDate(newDate, minutesFormat).length;
+          var seconds = newDate.getSeconds(), secondsLength = formatDate(newDate, secondsFormat).length;
           if (index === 0) {
             newDate.setHours(hours - (parseInt(options.hourStep, 10) * value));
           }
-          else {
+          else if (index === 1) {
             newDate.setMinutes(minutes - (parseInt(options.minuteStep, 10) * value));
+          }
+          else if (index === 2) {
+            newDate.setSeconds(seconds - (parseInt(options.secondStep, 10) * value));
           }
           $timepicker.select(newDate, index, true);
         };
@@ -196,11 +218,14 @@ angular.module('mgcrea.ngStrap.timepicker', [
         $timepicker.$moveIndex = function(value, index) {
           var targetDate;
           if(index === 0) {
-            targetDate = new Date(1970, 0, 1, viewDate.hour + (value * options.length), viewDate.minute);
+            targetDate = new Date(1970, 0, 1, viewDate.hour + (value * options.length), viewDate.minute, viewDate.second);
             angular.extend(viewDate, {hour: targetDate.getHours()});
           } else if(index === 1) {
-            targetDate = new Date(1970, 0, 1, viewDate.hour, viewDate.minute + (value * options.length * options.minuteStep));
+            targetDate = new Date(1970, 0, 1, viewDate.hour, viewDate.minute + (value * options.length * options.minuteStep), viewDate.second);
             angular.extend(viewDate, {minute: targetDate.getMinutes()});
+          } else if(index === 2) {
+            targetDate = new Date(1970, 0, 1, viewDate.hour, viewDate.minute, viewDate.second + (value * options.length * options.secondStep));
+            angular.extend(viewDate, {second: targetDate.getSeconds()});
           }
           $timepicker.$build();
         };
@@ -231,8 +256,10 @@ angular.module('mgcrea.ngStrap.timepicker', [
           var newDate = new Date($timepicker.$date);
           var hours = newDate.getHours(), hoursLength = formatDate(newDate, hoursFormat).length;
           var minutes = newDate.getMinutes(), minutesLength = formatDate(newDate, minutesFormat).length;
+          var seconds = newDate.getSeconds(), secondsLength = formatDate(newDate, secondsFormat).length;
+          var sepLength = 1;
           var lateralMove = /(37|39)/.test(evt.keyCode);
-          var count = 2 + showAM * 1;
+          var count = 2 + showSeconds * 1 + showAM * 1;
 
           // Navigate indexes (left, right)
           if (lateralMove) {
@@ -242,21 +269,29 @@ angular.module('mgcrea.ngStrap.timepicker', [
 
           // Update values (up, down)
           var selectRange = [0, hoursLength];
+          var incr = 0;
+          if (evt.keyCode === 38) incr = -1;
+          if (evt.keyCode === 40) incr = +1;
+          var isSeconds = selectedIndex === 2 && showSeconds;
+          var isMeridian = selectedIndex === 2 && !showSeconds || selectedIndex === 3 && showSeconds;
           if(selectedIndex === 0) {
-            if(evt.keyCode === 38) newDate.setHours(hours - parseInt(options.hourStep, 10));
-            else if(evt.keyCode === 40) newDate.setHours(hours + parseInt(options.hourStep, 10));
+            newDate.setHours(hours + incr*parseInt(options.hourStep, 10));
             // re-calculate hours length because we have changed hours value
             hoursLength = formatDate(newDate, hoursFormat).length;
             selectRange = [0, hoursLength];
           } else if(selectedIndex === 1) {
-            if(evt.keyCode === 38) newDate.setMinutes(minutes - parseInt(options.minuteStep, 10));
-            else if(evt.keyCode === 40) newDate.setMinutes(minutes + parseInt(options.minuteStep, 10));
+            newDate.setMinutes(minutes + incr*parseInt(options.minuteStep, 10));
             // re-calculate minutes length because we have changes minutes value
             minutesLength = formatDate(newDate, minutesFormat).length;
-            selectRange = [hoursLength + 1, hoursLength + 1 + minutesLength];
-          } else if(selectedIndex === 2) {
+            selectRange = [hoursLength + sepLength, minutesLength];
+          } else if(isSeconds) {
+            newDate.setSeconds(seconds + incr*parseInt(options.secondStep, 10));
+            // re-calculate seconds length because we have changes seconds value
+            secondsLength = formatDate(newDate, secondsFormat).length;
+            selectRange = [hoursLength + sepLength + minutesLength + sepLength, secondsLength];
+          } else if(isMeridian) {
             if(!lateralMove) $timepicker.switchMeridian();
-            selectRange = [hoursLength + 1 + minutesLength + 1, hoursLength + 1 + minutesLength + 3];
+            selectRange = [hoursLength + sepLength + minutesLength + sepLength + (secondsLength + sepLength)*showSeconds, 2];
           }
           $timepicker.select(newDate, selectedIndex, true);
           createSelection(selectRange[0], selectRange[1]);
@@ -265,7 +300,8 @@ angular.module('mgcrea.ngStrap.timepicker', [
 
         // Private
 
-        function createSelection(start, end) {
+        function createSelection(start, length) {
+          var end = start + length;
           if(element[0].createTextRange) {
             var selRange = element[0].createTextRange();
             selRange.collapse(true);
@@ -356,7 +392,7 @@ angular.module('mgcrea.ngStrap.timepicker', [
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'secondStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'id'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/timepicker/timepicker.tpl.html
+++ b/src/timepicker/timepicker.tpl.html
@@ -15,6 +15,14 @@
           <i class="{{ $iconUp }}"></i>
         </button>
       </th>
+      <th>
+        &nbsp;
+      </th>
+      <th>
+        <button ng-if="showSeconds" tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$arrowAction(-1, 2)">
+          <i class="{{ $iconUp }}"></i>
+        </button>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -30,6 +38,14 @@
       <td class="text-center">
         <button tabindex="-1" ng-if="row[1].date" style="width: 100%" type="button" class="btn btn-default" ng-class="{'btn-primary': row[1].selected}" ng-click="$select(row[1].date, 1)" ng-disabled="row[1].disabled">
           <span ng-class="{'text-muted': row[1].muted}" ng-bind="row[1].label"></span>
+        </button>
+      </td>
+      <td>
+        <span ng-bind="i == midIndex ? timeSeparator : ' '"></span>
+      </td>
+      <td class="text-center">
+        <button tabindex="-1" ng-if="showSeconds && row[2].date" style="width: 100%" type="button" class="btn btn-default" ng-class="{'btn-primary': row[2].selected}" ng-click="$select(row[2].date, 2)" ng-disabled="row[2].disabled">
+          <span ng-class="{'text-muted': row[2].muted}" ng-bind="row[2].label"></span>
         </button>
       </td>
       <td ng-if="showAM">
@@ -53,6 +69,14 @@
       </th>
       <th>
         <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$arrowAction(1, 1)">
+          <i class="{{ $iconDown }}"></i>
+        </button>
+      </th>
+      <th>
+        &nbsp;
+      </th>
+      <th>
+        <button ng-if="showSeconds" tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$arrowAction(1, 2)">
           <i class="{{ $iconDown }}"></i>
         </button>
       </th>


### PR DESCRIPTION
This makes possible to edit the seconds with the timepicker, as requested in #1417. I did not make the milliseconds but it should be pretty straighforward following my modifications.

I updated the unit tests so they also check the seconds, and added a few that are more specific to that feature. I edited the unit test for "roundDisplay" so it mocks the clock in order to be reproducible. I also updated the example in the documentation of the timepicker.

Potentially breaking changes :
* Seconds dropdown is shown automatically if timeFormat include them (ex : h:mm:ss)
* Added parameter secondStep
* Meridian field (AM/PM) is now at position 6 instead of 4 (replaced by seconds field)

PS : this is my first pull-request, I hope I did everything right but don't be too rude if it's not the case :sweat_smile: 

Edit : ok there are still bugs. Sorry about it, I'm gonna check that.