### PR TITLE
feat(typeahead): if value attr exist use value instead of label when selected

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -36,8 +36,8 @@ angular.module('mgcrea.ngStrap.datepicker', [
       minView: 0,
       startWeek: 0,
       daysOfWeekDisabled: '',
-      iconLeft: 'glyphicon glyphicon-chevron-left',
-      iconRight: 'glyphicon glyphicon-chevron-right'
+      iconLeft: '&laquo;',
+      iconRight: '&raquo;'
     };
 
     this.$get = function($window, $document, $rootScope, $sce, $dateFormatter, datepickerViews, $tooltip, $timeout) {

--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -3,9 +3,7 @@
   <thead>
     <tr class="text-center">
       <th>
-        <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$selectPane(-1)">
-          <i class="{{$iconLeft}}"></i>
-        </button>
+        <button tabindex="-1" type="button" class="btn btn-default pull-left" ng-click="$selectPane(-1)" ng-bind-html="$iconLeft"></button>
       </th>
       <th colspan="{{ rows[0].length - 2 }}">
         <button tabindex="-1" type="button" class="btn btn-default btn-block text-strong"  ng-click="$toggleMode()">
@@ -13,9 +11,7 @@
         </button>
       </th>
       <th>
-        <button tabindex="-1" type="button" class="btn btn-default pull-right" ng-click="$selectPane(+1)">
-          <i class="{{$iconRight}}"></i>
-        </button>
+        <button tabindex="-1" type="button" class="btn btn-default pull-right" ng-click="$selectPane(+1)" ng-bind-html="$iconRight"></button>
       </th>
     </tr>
     <tr ng-show="showLabels" ng-bind-html="labels"></tr>

--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -235,17 +235,17 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
         <tr>
           <td>iconLeft</td>
           <td>string</td>
-          <td>'glyphicon glyphicon-chevron-left'</td>
+          <td>'&laquo;'</td>
           <td>
-            <p>CSS class for 'left' icon.</p>
+            <p>html for 'left' icon.</p>
           </td>
         </tr>
         <tr>
           <td>iconRight</td>
           <td>string</td>
-          <td>'glyphicon glyphicon-chevron-right'</td>
+          <td>'&raquo;'</td>
           <td>
-            <p>CSS class for 'right' icon.</p>
+            <p>html for 'right' icon.</p>
           </td>
         </tr>
         <tr>

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -263,7 +263,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           // console.warn('$render', element.attr('ng-model'), 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue, 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
           if(controller.$isEmpty(controller.$viewValue)) return element.val('');
           var index = typeahead.$getIndex(controller.$modelValue);
-          var selected = angular.isDefined(index) ? typeahead.$scope.$matches[index].label : controller.$viewValue;
+          var selected = angular.isDefined(index) ? typeahead.$scope.$matches[index].value.value || typeahead.$scope.$matches[index].label : controller.$viewValue;
           selected = angular.isObject(selected) ? parsedOptions.displayValue(selected) : selected;
           element.val(selected ? selected.toString().replace(/<(?:.|\n)*?>/gm, '').trim() : '');
         };


### PR DESCRIPTION
change behavior when select object like :
```javascript
 {
    value: 'some value'
    ,label: 'label html'
}
```
output `value` to the input element instead of label.
