### PR TITLE
Enable prefixEvent and prefixClass on several directives

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -9,6 +9,8 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
     var defaults = this.defaults = {
       animation: 'am-fade',
+      //uncommenting the following line will break backwards compatability
+      // prefixEvent: 'datepicker',
       prefixClass: 'datepicker',
       placement: 'bottom-left',
       template: 'datepicker/datepicker.tpl.html',
@@ -266,7 +268,7 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'html', 'animation', 'template', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id', 'prefixClass', 'prefixEvent'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -35,6 +35,10 @@ describe('datepicker', function() {
       scope: {selectedDate: new Date()},
       element: '<input type="text" ng-model="selectedDate" bs-datepicker>'
     },
+    'default-with-namespace': {
+      scope: {selectedDate: new Date()},
+      element: '<input type="text" ng-model="selectedDate" bs-datepicker data-prefix-event="modal">'
+    },
     'default-with-id': {
       scope: {selectedDate: new Date()},
       element: '<input id="datepicker1" type="text" ng-model="selectedDate" bs-datepicker>'
@@ -1418,5 +1422,51 @@ describe('datepicker', function() {
       datepickerViews.views[2].onKeyDown({ keyCode: 40 });
       expect(picker.select).not.toHaveBeenCalled();
     }));
+  });
+
+  describe('prefix', function () {
+    it('should call namespaced events from provider', function() {
+      var myDatepicker = $datepicker(sandboxEl, null, {prefixEvent: 'dp', scope : scope});
+      var emit = spyOn(myDatepicker.$scope, '$emit');
+      scope.$digest();
+      myDatepicker.show();
+      myDatepicker.hide();
+      $animate.triggerCallbacks();
+
+      expect(emit).toHaveBeenCalledWith('dp.show.before', myDatepicker);
+      expect(emit).toHaveBeenCalledWith('dp.show', myDatepicker);
+      expect(emit).toHaveBeenCalledWith('dp.hide.before', myDatepicker);
+      expect(emit).toHaveBeenCalledWith('dp.hide', myDatepicker);
+    });
+
+    it('should call namespaced events from directive', function() {
+      var elm = compileDirective('default-with-namespace');
+      var showBefore, show, hideBefore, hide;
+      scope.$on('modal.show.before', function() {
+        showBefore = true;
+      });
+      scope.$on('modal.show', function() {
+        show = true;
+      });
+      scope.$on('modal.hide.before', function() {
+        hideBefore = true;
+      });
+      scope.$on('modal.hide', function() {
+        hide = true;
+      });
+
+      angular.element(elm[0]).triggerHandler('focus');
+      $animate.triggerCallbacks();
+
+      expect(showBefore).toBe(true);
+      expect(show).toBe(true);
+
+      angular.element(elm[0]).triggerHandler('blur');
+      $animate.triggerCallbacks();
+
+      expect(hideBefore).toBe(true);
+      expect(hide).toBe(true);
+    });
+
   });
 });

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -300,7 +300,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.helpers.dimensions'])
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'id'], function(key) {
+        angular.forEach(['template', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'id', 'prefixEvent', 'prefixClass'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -36,6 +36,10 @@ describe('modal', function() {
       scope: {modal: {title: 'Title', content: 'Hello Modal!'}},
       element: '<a title="{{modal.title}}" data-content="{{modal.content}}" bs-modal>click me</a>'
     },
+    'default-with-namespace': {
+      scope: {modal: {title: 'Title', content: 'Hello Modal!'}},
+      element: '<a title="{{modal.title}}" data-content="{{modal.content}}" bs-modal data-prefix-event="datepicker">click me</a>'
+    },
     'default-with-id': {
       scope: {modal: {title: 'Title', content: 'Hello Modal!'}},
       element: '<a id="modal1" title="{{modal.title}}" data-content="{{modal.content}}" bs-modal>click me</a>'
@@ -316,6 +320,35 @@ describe('modal', function() {
       angular.element(elm[0]).triggerHandler('click');
       scope.$digest();
       expect(id).toBe('modal1');
+    });
+
+    it('should call namespaced events through directive', function() {
+      var elm = compileDirective('default-with-namespace');
+      var showBefore, show, hide, hideBefore;
+      scope.$on('datepicker.show.before', function() {
+        showBefore = true;
+      });
+      scope.$on('datepicker.show', function() {
+        show = true;
+      });
+      scope.$on('datepicker.hide.before', function() {
+        hideBefore = true;
+      });
+      scope.$on('datepicker.hide', function() {
+        hide = true;
+      });
+
+      angular.element(elm[0]).triggerHandler('click');
+      $animate.triggerCallbacks();
+
+      expect(showBefore).toBe(true);
+      expect(show).toBe(true);
+
+      angular.element(elm[0]).triggerHandler('click');
+      $animate.triggerCallbacks();
+
+      expect(hideBefore).toBe(true);
+      expect(hide).toBe(true);
     });
 
   });

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -7,6 +7,9 @@ angular.module('mgcrea.ngStrap.popover', ['mgcrea.ngStrap.tooltip'])
     var defaults = this.defaults = {
       animation: 'am-fade',
       customClass: '',
+      // uncommenting the next two lines will break backwards compatability
+      // prefixClass: 'popover',
+      // prefixEvent: 'popover',
       container: false,
       target: false,
       placement: 'right',
@@ -56,7 +59,7 @@ angular.module('mgcrea.ngStrap.popover', ['mgcrea.ngStrap.tooltip'])
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'customClass', 'autoClose', 'id'], function(key) {
+        angular.forEach(['template', 'contentTemplate', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'customClass', 'autoClose', 'id', 'prefixClass', 'prefixEvent'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/popover/test/popover.spec.js
+++ b/src/popover/test/popover.spec.js
@@ -35,6 +35,10 @@ describe('popover', function () {
       scope: {popover: {title: 'Title', content: 'Hello Popover!'}},
       element: '<a class="btn" title="{{popover.title}}" data-content="{{popover.content}}" bs-popover></a>'
     },
+    'default-with-namespace': {
+      scope: {popover: {title: 'Title', content: 'Hello Popover!'}},
+      element: '<a class="btn" title="{{popover.title}}" data-content="{{popover.content}}" bs-popover data-prefix-event="datepicker"></a>'
+    },
     'default-with-id': {
       scope: {popover: {title: 'Title', content: 'Hello Popover!'}},
       element: '<a id="popover1" class="btn" title="{{popover.title}}" data-content="{{popover.content}}" bs-popover></a>'
@@ -461,6 +465,52 @@ describe('popover', function () {
 
     });
 
+    describe('prefix', function () {
+      it('should call namespaced events through provider', function() {
+        var myPopover = $popover(sandboxEl, angular.extend({prefixEvent: 'datepicker'}, templates['default'].scope.popover));
+        var emit = spyOn(myPopover.$scope, '$emit');
+        scope.$digest();
+        myPopover.show();
+        myPopover.hide();
+        $animate.triggerCallbacks();
+
+        expect(emit).toHaveBeenCalledWith('datepicker.show.before', myPopover);
+        expect(emit).toHaveBeenCalledWith('datepicker.show', myPopover);
+        expect(emit).toHaveBeenCalledWith('datepicker.hide.before', myPopover);
+        expect(emit).toHaveBeenCalledWith('datepicker.hide', myPopover);
+      });
+
+
+      it('should call namespaced events through directive', function() {
+        var elm = compileDirective('default-with-namespace');
+        var showBefore, show, hide, hideBefore;
+        scope.$on('datepicker.show.before', function() {
+          showBefore = true;
+        });
+        scope.$on('datepicker.show', function() {
+          show = true;
+        });
+        scope.$on('datepicker.hide.before', function() {
+          hideBefore = true;
+        });
+        scope.$on('datepicker.hide', function() {
+          hide = true;
+        });
+
+        angular.element(elm[0]).triggerHandler('click');
+        $animate.triggerCallbacks();
+
+        expect(showBefore).toBe(true);
+        expect(show).toBe(true);
+
+        angular.element(elm[0]).triggerHandler('click');
+        $animate.triggerCallbacks();
+
+        expect(hideBefore).toBe(true);
+        expect(hide).toBe(true);
+      });
+
+    });
 
   });
 

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -252,7 +252,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -33,6 +33,10 @@ describe('timepicker', function() {
       scope: {selectedTime: new Date()},
       element: '<input type="text" ng-model="selectedTime" bs-timepicker>'
     },
+    'default-with-namespace': {
+      scope: {selectedTime: new Date()},
+      element: '<input type="text" ng-model="selectedTime" bs-timepicker data-prefix-event="datepicker">'
+    },
     'default-with-id': {
       scope: {selectedTime: new Date()},
       element: '<input id="timepicker1" type="text" ng-model="selectedTime" bs-timepicker>'
@@ -1211,6 +1215,52 @@ describe('timepicker', function() {
       })
 
     })
+
+    describe('prefix', function () {
+      it('should call namespaced events through provider', function() {
+        var myTimepicker = $timepicker(sandboxEl, { $datevalue: new Date() }, {prefixEvent: 'datepicker', scope : scope});
+        var emit = spyOn(myTimepicker.$scope, '$emit');
+        scope.$digest();
+        myTimepicker.show();
+        myTimepicker.hide();
+        $animate.triggerCallbacks();
+
+        expect(emit).toHaveBeenCalledWith('datepicker.show.before', myTimepicker);
+        expect(emit).toHaveBeenCalledWith('datepicker.show', myTimepicker);
+        expect(emit).toHaveBeenCalledWith('datepicker.hide.before', myTimepicker);
+        expect(emit).toHaveBeenCalledWith('datepicker.hide', myTimepicker);
+      });
+
+      it('should call namespaced events through directive', function() {
+        var elm = compileDirective('default-with-namespace');
+        var showBefore, show, hideBefore, hide;
+        scope.$on('datepicker.show.before', function() {
+          showBefore = true;
+        });
+        scope.$on('datepicker.show', function() {
+          show = true;
+        });
+        scope.$on('datepicker.hide.before', function() {
+          hideBefore = true;
+        });
+        scope.$on('datepicker.hide', function() {
+          hide = true;
+        });
+
+        angular.element(elm[0]).triggerHandler('focus');
+        $animate.triggerCallbacks();
+
+        expect(showBefore).toBe(true);
+        expect(show).toBe(true);
+
+        angular.element(elm[0]).triggerHandler('blur');
+        $animate.triggerCallbacks();
+
+        expect(hideBefore).toBe(true);
+        expect(hide).toBe(true);
+      });
+
+    });
 
   });
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -9,6 +9,8 @@ angular.module('mgcrea.ngStrap.timepicker', [
 
     var defaults = this.defaults = {
       animation: 'am-fade',
+      //uncommenting the following line will break backwards compatability
+      // prefixEvent: 'timepicker',
       prefixClass: 'timepicker',
       placement: 'bottom-left',
       template: 'timepicker/timepicker.tpl.html',
@@ -392,7 +394,7 @@ angular.module('mgcrea.ngStrap.timepicker', [
 
         // Directive options
         var options = {scope: scope, controller: controller};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'secondStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'roundDisplay', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'secondStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'roundDisplay', 'id', 'prefixClass', 'prefixEvent'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -188,7 +188,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'autoSelect', 'comparator', 'id'], function(key) {
+        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'filter', 'limit', 'minLength', 'watchOptions', 'selectMode', 'autoSelect', 'comparator', 'id', 'prefixEvent', 'prefixClass'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
This adds the 'prefixEvent' and 'prefixClass' configurable options to the directives of the datepicker, modal, popover, select, timepicker and typeahead modules.

These changes should not break backwards compatability. In some of the directives 'prefixEvent' and 'prefixClass' were not in the module defaults. I have added them in **commented out** as uncommenting them will break backwards compatability. I propose in a future major version that these lines be uncommented as well as the naming of these defaults be standardized (in some cases the event prefix name starts with `$` other times not).

Fixes #1559 and #1578