### PR TITLE
docs(datepicker): document timezone option for bs-datepicker

### DIFF
--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -168,6 +168,15 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
             <p>If type is "number" then datepicker uses milliseconds to set date, if "unix" - seconds</p>
           </td>
         </tr>
+		<tr>
+          <td>timezone</td>
+          <td>string</td>
+          <td>null</td>
+          <td>
+            <p>Timezone of your date - UTC</p>
+            <p>Right now, only "UTC" is supported.</p>
+          </td>
+        </tr>
         <tr>
           <td>autoclose</td>
           <td>boolean</td>


### PR DESCRIPTION
Added missing documentation for the timezone option for bs-datepicker