### PR TITLE
feat(select): Add ability to have a high end limit on multiselect.

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -257,7 +257,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent'], function(key) {
+        angular.forEach(['limit', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'template', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
@@ -306,6 +306,24 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         // Watch model for changes
         scope.$watch(attr.ngModel, function(newValue, oldValue) {
           // console.warn('scope.$watch(%s)', attr.ngModel, newValue, oldValue);
+          var limit = (angular.isDefined(options.limit)) ? parseInt(options.limit, 10) : undefined;
+          if(options.multiple && limit !== undefined){
+            if(newValue != null){
+              if(limit < newValue.length){
+                for(var i = 0; i < newValue.length; i++){
+                  if(i >= oldValue.length) break;
+                  if(!angular.equals(newValue[i], oldValue[i])) break;
+                }
+
+                if(i === newValue.length){
+                  newValue.pop();
+                }else{
+                  newValue.splice(i, 1);
+                }
+              }
+            }
+          }
+
           select.$updateActiveIndex();
           controller.$render();
         }, true);

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -69,6 +69,10 @@ describe('select', function () {
       scope: {selectedIcons: ['Globe'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
       element: '<button type="button" class="btn" data-multiple="1" ng-model="selectedIcons" bs-options="icon.value as icon.label for icon in icons" required bs-select></button>'
     },
+    'options-multiple-limit': {
+      scope: {selectedIcons: ['Globe', 'Heart', 'Camera'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
+      element: '<button type="button" class="btn" data-multiple="1" data-limit="2" ng-model="selectedIcons" bs-options="icon.value as icon.label for icon in icons" bs-select></button>'
+    },
     'options-maxLength': {
       scope: {selectedIcons: ['Globe', 'Heart', 'Camera'], icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
       element: '<button type="button" class="btn" data-multiple="1" data-max-length="2" ng-model="selectedIcons" bs-options="icon.value as icon.label for icon in icons" bs-select></button>'
@@ -169,7 +173,7 @@ describe('select', function () {
       expect(sandboxEl.find('.dropdown-menu li').length).toBe(scope.icons.length);
       expect(sandboxEl.find('.dropdown-menu li:eq(0)').text().trim()).toBe(scope.icons[0].label);
     });
-    
+
     it('should support null ng-model initial value', function() {
       var elm = compileDirective('default', { selectedIcon: null });
       expect(function() { angular.element(elm[0]).triggerHandler('focus') }).not.toThrow();
@@ -312,6 +316,24 @@ describe('select', function () {
         expect(function() { angular.element(elm[0]).triggerHandler('focus') }).not.toThrow();
         angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
         expect(scope.selectedIcons).toEqual([ scope.icons[1].value ]);
+      });
+    });
+
+    describe('limit', function(){
+      it('Should not allow you to select more options that specified by the limit', function(){
+        var elm = compileDirective('options-multiple-limit', { selectedIcons: null });
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.find('.dropdown-menu li.active').length).toBe(0);
+
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcons.length).toEqual(1);
+
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(2) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcons.length).toEqual(2);
+
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(3) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcons.length).toEqual(2);
+        expect(sandboxEl.find('.dropdown-menu li.active').length).toBe(2);
       });
     });
 


### PR DESCRIPTION
add ability to have high end limit on a multislect. This allows the user
to choose more than one option but no more than the high end limit.
currently there is no ability to limit the number of selected items.

based on issue #786
