### PR TITLE
feat (tooltip): add "redraw" event listener

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -578,6 +578,42 @@ describe('tooltip', function() {
 
   });
 
+  describe('redraw event listener', function () {
+    it('should listen for redraw events', function() {
+      var myTooltip = $tooltip(sandboxEl, templates['default'].scope.tooltip);
+      var applyPlacement = spyOn(myTooltip, '$applyPlacement');
+      scope.$digest();
+
+      myTooltip.show();
+      $rootScope.$broadcast('tooltip.redraw');
+      myTooltip.hide();
+      $animate.triggerCallbacks();
+      $rootScope.$broadcast('tooltip.redraw');
+
+      // $applyPlacement should have been called twice: immediately after show
+      // and again after the first $broadcast. The second $broadcast should not
+      // result in an $applyPlacement call because the tooltip was hidden
+      expect(applyPlacement.calls.count()).toEqual(2);
+    });
+
+    it('should listen for the namespaced redraw event', function() {
+      var myTooltip = $tooltip(sandboxEl, angular.extend({prefixEvent: 'datepicker'}, templates['default'].scope.tooltip));
+      var applyPlacement = spyOn(myTooltip, '$applyPlacement');
+      scope.$digest();
+
+      myTooltip.show();
+      $rootScope.$broadcast('datepicker.redraw');
+      myTooltip.hide();
+      $animate.triggerCallbacks();
+      $rootScope.$broadcast('datepicker.redraw');
+
+      // $applyPlacement should have been called twice: immediately after show
+      // and again after the first $broadcast. The second $broadcast should not
+      // result in an $applyPlacement call because the tooltip was hidden
+      expect(applyPlacement.calls.count()).toEqual(2);
+    });
+  });
+
   describe('show / hide events', function() {
 
     it('should dispatch show and show.before events', function() {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -180,6 +180,12 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.helpers.dimensions'])
 
         };
 
+        scope.$on(options.prefixEvent + '.redraw', function () {
+          if ($tooltip.$isShown) {
+            $tooltip.$applyPlacement();
+          }
+        });
+
         $tooltip.show = function() {
           if (!options.bsEnabled || $tooltip.$isShown) return;
 


### PR DESCRIPTION
Tooltip now listens for a "redraw" event which signals that the displayed
tooltip should be repositioned. Use cases: When the triggering DOM
element is repositioned while the tooltip is active, the "redraw" event can
be emitted/broadcast and the tooltip will remains adjacent the DOM element.
When the dimensions of a tooltip's template change, the "redraw" event can
be emitted/broadcast and the tooltip will remain centered next to the
triggering DOM element.

This is a possible solution to #1497.