### PR TITLE
feat(date-parser): change parsing of 'y' format option to support parsing of 2 and 4 year

### DIFF
--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -114,7 +114,7 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
         'M'     : function(value) { return this.setMonth(1 * value - 1); },
         'yyyy'  : proto.setFullYear,
         'yy'    : function(value) { return this.setFullYear(2000 + 1 * value); },
-        'y'     : proto.setFullYear
+        'y'     : function(value) { return (1 * value <= 50 && value.length === 2) ? this.setFullYear(2000 + 1 * value) : this.setFullYear(1 * value); }
       };
 
       var regex, setMap;

--- a/src/helpers/test/date-parser.spec.js
+++ b/src/helpers/test/date-parser.spec.js
@@ -297,6 +297,22 @@ describe('dateParser', function () {
           {val:'30/02/2014', expect: false, reason:'non-existing month day'},
         ]);
     });
+	
+	describe('date format "M/d/y"', function(){
+		beforeEach(function() {
+          parser = $dateParser({ format: 'M/d/y' });
+        });
+		
+		generateTestCasesForParsing([
+          {val: '1/1/1',    expect: new Date(1,0,1),    reason:'1 digit year gives one digit year'},
+          {val: '1/1/00',   expect: new Date(2000,0,1), reason:'2 digit year less than fifty gives current century'},
+          {val: '1/1/50',   expect: new Date(2050,0,1), reason:'2 digit year equal to fifty gives current century'},
+          {val: '1/1/51',   expect: new Date(1951,0,1), reason:'2 digit year greater than fifty gives previous century'},
+          {val: '1/1/99',   expect: new Date(1999,0,1), reason:'2 digit year, maximum possible, gives previous century'},
+		  {val: '1/1/123',  expect: new Date(123,0,1),  reason:'3 digit year gives three digit year'},
+		  {val: '1/1/2015', expect: new Date(2015,0,1), reason:'4 digit year gives four digit year'},		  
+		]);	  
+	});
 
     describe('date format "dd/MM/yyyy" with base values', function() {
 
@@ -349,8 +365,8 @@ describe('dateParser', function () {
       });
 
     });
-
-    describe('date format is "MMM" (month initials)', function() {
+	
+	describe('date format is "MMM" (month initials)', function() {
       beforeEach(function() {
         $locale.id = 'en-US';
         parser = $dateParser({format: 'MMM'});


### PR DESCRIPTION
declarations with the same format

I am trying to support the ability to type in either a date with two or four digits for the year in
 a date. This is possible by setting the 'y' format for the year. However, inputting a two digit
date with the 'y' format produces a date from 20th century instead of the 21st. The change
suggested would take any two digit year below or equal to fifty and return the 21st century
equivalent. e.g. inputting a year of 15 now produces 2015 instead of 1915.

This change will cause anyone relying on the behavior of the 'y' format to produce 1915 from an
input of 14 to break as it would now produce 2015.