### PR TITLE
feat(bsTabs): allow to bind selected tab by name

### DIFF
--- a/src/tab/docs/tab.demo.html
+++ b/src/tab/docs/tab.demo.html
@@ -156,6 +156,14 @@ $scope.tabs.activeTab = {{ tabs.activeTab }};
             <p>Disable pane</p>
           </td>
         </tr>
+        <tr>
+          <td>name</td>
+          <td>string</td>
+          <td>''</td>
+          <td>
+            <p>Tab name. If provided, it will be used for `bsActivePane` instead of number</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -192,7 +200,7 @@ $scope.tabs.activeTab = {{ tabs.activeTab }};
           <td>bsActivePane</td>
           <td>number</td>
           <td>
-            <p>Binds to the active tab pane index (zero based).</p>
+            <p>Info about current selected tab. If it has the name, it will be here, otherwise – active tab pane index (zero based).</p>
             <p>You can use it to set the active tab pane from code or to get the currently active tab pane.</p>
           </td>
         </tr>

--- a/src/tab/tab.tpl.html
+++ b/src/tab/tab.tpl.html
@@ -1,6 +1,6 @@
 <ul class="nav" ng-class="$navClass" role="tablist">
-  <li role="presentation" ng-repeat="$pane in $panes track by $index" ng-class="[ $index == $panes.$active ? $activeClass : '', $pane.disabled ? 'disabled' : '' ]">
-    <a role="tab" data-toggle="tab" ng-click="!$pane.disabled && $setActive($index)" data-index="{{ $index }}" ng-bind-html="$pane.title" aria-controls="$pane.title"></a>
+  <li role="presentation" ng-repeat="$pane in $panes track by $index" ng-class="[ $isActive($pane, $index) ? $activeClass : '', $pane.disabled ? 'disabled' : '' ]">
+    <a role="tab" data-toggle="tab" ng-click="!$pane.disabled && $setActive($pane.name || $index)" data-index="{{ $index }}" ng-bind-html="$pane.title" aria-controls="$pane.title"></a>
   </li>
 </ul>
 <div ng-transclude class="tab-content">

--- a/src/tab/test/tab.spec.js
+++ b/src/tab/test/tab.spec.js
@@ -40,6 +40,10 @@ describe('tab', function () {
       scope: {tab: {active: 1}},
       element: '<div ng-model="tab.active" bs-tabs><div title="title-1" bs-pane>content-1</div><div title="title-2" bs-pane>content-2</div></div>'
     },
+    'binding-named-ngModel': {
+      scope: {tab: {active: 'title-1'}},
+      element: '<div ng-model="tab.active" bs-tabs><div title="title-1" name="title-1" bs-pane>content-1</div><div title="title-2" name="title-2" bs-pane>content-2</div></div>'
+    },
     'template-ngModel-ngRepeat': {
       scope: {
         tab: {active: 1},
@@ -49,6 +53,10 @@ describe('tab', function () {
           {title:'About', content: 'Etsy mixtape wayfarers...'}
       ]},
       element: '<div ng-model="tab.active" bs-tabs><div ng-repeat="tab in tabs" title="{{ tab.title }}" ng-bind="tab.content" bs-pane></div>'
+    },
+    'binding-named-bsActivePane': {
+      scope: {tab: {active: 'title-1'}},
+      element: '<div bs-active-pane="tab.active" bs-tabs><div title="title-1" name="title-1" bs-pane>content-1</div><div title="title-2" name="title-2" bs-pane>content-2</div></div>'
     },
     'binding-bsActivePane': {
       scope: {tab: {active: 1}},
@@ -210,6 +218,18 @@ describe('tab', function () {
         var elm = compileDirective('binding-' + bindingAttribute);
         sandboxEl.find('.nav-tabs > li:eq(0) > a').triggerHandler('click');
         expect(scope.tab.active).toBe(0);
+      });
+
+      it('should set active tab by name', function() {
+        var elm = compileDirective('binding-named-' + bindingAttribute, {tab: {active: 'title-2'}});
+        expect(sandboxEl.find('.nav-tabs > li.active').index()).toBe(1);
+        expect(sandboxEl.find('.tab-content > .tab-pane.active').attr('name')).toBe('title-2');
+      });
+
+      it('should set tab name into model if it is provided', function() {
+        var elm = compileDirective('binding-named-' + bindingAttribute);
+        sandboxEl.find('.nav-tabs > li:eq(1) > a').triggerHandler('click');
+        expect(scope.tab.active).toBe('title-2');
       });
 
       it('should keep active pane when adding a new pane after', function() {


### PR DESCRIPTION
It is useful sometimes to select tab by its name. This feature introducing support of `name` attribute on `bs-pane`:

```html
<div bs-active-pane="tabs.activeTab" bs-tabs>
    <div ng-repeat="tab in tabs" title="{{ tab.title }}" name="{{ tab.title }}" disabled="{{ tab.disabled }}" ng-bind="tab.content" bs-pane></div>
</div>
```
If you set names for your tabs, it will be used as `bs-active-pane` instead of number. Backward binding also works, you can set string into `tabs.activeTab` and tab with this name is exists, it will be activated.

This feature allows to make wonderful things, such as tabs switching via `location.hash` or activating tab by name without sense for tabs order.