### PR TITLE
fix(typeahead): if display value cannot be determined, use the model value

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -274,6 +274,10 @@ describe('typeahead', function () {
       expect(elm.val()).toBe(jQuery('div').html(scope.states[0]).text().trim());
     });
 
+    it('should use the model value if the display value cannot be determined', function () {
+      var elm = compileDirective('markup-objectValue', {}, function(scope) { scope.selectedIcon = 'Ge' });
+      expect(elm.val()).toBe('Ge'); // display value will be undefined, use model value for display
+    });
   });
 
   describe('bsOptions', function () {

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -278,6 +278,11 @@ describe('typeahead', function () {
       var elm = compileDirective('markup-objectValue', {}, function(scope) { scope.selectedIcon = 'Ge' });
       expect(elm.val()).toBe('Ge'); // display value will be undefined, use model value for display
     });
+
+    it('should use \'\' if the  model is an object and the display value cannot be determined', function () {
+      var elm = compileDirective('markup-objectValue', {}, function(scope) { scope.selectedIcon = {} });
+      expect(elm.val()).toBe('');
+    });
   });
 
   describe('bsOptions', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -146,7 +146,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         $typeahead.show = function() {
           show();
           // use timeout to hookup the events to prevent
-          // event bubbling from being processed imediately.
+          // event bubbling from being processed immediately.
           $timeout(function() {
             $typeahead.$element && $typeahead.$element.on('mousedown', $typeahead.$onMouseDown);
             if(options.keyboard) {
@@ -255,7 +255,16 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         controller.$formatters.push(function(modelValue) {
           // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
           var displayValue = parsedOptions.displayValue(modelValue);
-          return displayValue === undefined ? '' : displayValue;
+
+          // If we can determine the displayValue, use that
+          if (displayValue) return displayValue;
+
+          // If there's no display value, attempt to use the modelValue.
+          // If the model is an object not much we can do
+          if (modelValue && typeof modelValue !== 'object') {
+            return modelValue;
+          }
+          return '';
         });
 
         // Model rendering in view


### PR DESCRIPTION
If the element's model is not found in the typeahead's options, use the model as the element's value instead of an empty string. Fixes #1702