### PR TITLE
DatePicker Docs - null timezone explanation

### DIFF
--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -173,8 +173,8 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
           <td>string</td>
           <td>null</td>
           <td>
-            <p>Timezone of your date - UTC</p>
-            <p>Right now, only "UTC" is supported.</p>
+            <p>Timezone of your date - null, UTC</p>
+            <p>"UTC" for UTC or null for local timezone.</p>
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Updated DatePicker docs to be more intuitive as it seems as if UTC is always being used as it is the only option which is not the case. If left null it will use the local timezone.