### PR TITLE
Correct element width if affix is middle

### DIFF
--- a/src/affix/affix.js
+++ b/src/affix/affix.js
@@ -94,9 +94,6 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
           if(affixed === affix) return;
           affixed = affix;
 
-          // Add proper affix class
-          element.removeClass(reset).addClass('affix' + ((affix !== 'middle') ? '-' + affix : ''));
-
           if(affix === 'top') {
             unpin = null;
             if(setWidth) {
@@ -132,6 +129,9 @@ angular.module('mgcrea.ngStrap.affix', ['mgcrea.ngStrap.helpers.dimensions', 'mg
               element.css('top', initialAffixTop + 'px');
             }
           }
+
+          // Add proper affix class
+          element.removeClass(reset).addClass('affix' + ((affix !== 'middle') ? '-' + affix : ''));
 
         };
 


### PR DESCRIPTION
The `affix` class should be added **after** resolving the element width https://github.com/mgcrea/angular-strap/blob/master/src/affix/affix.js#L128

Otherwise `.affix` / `position: fixed` would alter the proper element width.

This bug occurs if you refresh the page when the affix is on middle.