### PR TITLE
fix(typeahead): make watchOptions work with trimValue

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -218,7 +218,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         // Watch options on demand
         if(options.watchOptions) {
           // Watch bsOptions values before filtering for changes, drop function calls
-          var watchedOptions = parsedOptions.$match[7].replace(/\|.+/, '').replace(/\(.*\)/g, '').trim();
+          var parsedValue = parsedOptions.$match[7].replace(/\|.+/, '').replace(/\(.*\)/g, '');
+          var watchedOptions = (options.trimValue === false) ? parsedValue : parsedValue.trim();
           scope.$watchCollection(watchedOptions, function (newValue, oldValue) {
             // console.warn('scope.$watch(%s)', watchedOptions, newValue, oldValue);
             parsedOptions.valuesFn(scope, controller).then(function (values) {


### PR DESCRIPTION
Update to watchOptions code block to check for the trimValue option before trimming spaces from the parsed input. See issue #1752.