### PR TITLE
Fix for Chrome - v43.0.2357.130 doesn't consider autocomplete="off" but "false"

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -199,7 +199,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         });
 
         // Disable browser autocompletion
-        element.attr('autocomplete' ,'off');
+        element.attr('autocomplete' ,'false');
 
         // Build proper bsOptions
         var filter = options.filter || defaults.filter;


### PR DESCRIPTION
Typeahead recently became impossible to use on Chrome, the browser doesn't respect autocomplete="off" in last version anymore, and the native autocomplete hides the typeahead... autocomplete="false" works

(see http://stackoverflow.com/questions/15738259/disabling-chrome-autofill)