### PR TITLE
In typeahead service, scope.$activeIndex should be reset on ANY update

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -64,9 +64,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
         $typeahead.update = function(matches) {
           scope.$matches = matches;
-          if (scope.$activeIndex >= matches.length) {
-            scope.$activeIndex = options.autoSelect ? 0 : -1;
-          }
+          scope.$activeIndex = options.autoSelect ? 0 : -1;
 
           // wrap in a $timeout so the results are updated
           // before repositioning


### PR DESCRIPTION
Currently, unless you specify `autoselect`, the activeindex(pointing to the currently selected/highlighted item) remains mostly set once you set it using keyboard, even as you modify your typeahead 'query'

https://github.com/mgcrea/angular-strap/blob/master/src/typeahead/typeahead.js#L67-L69

``` javascript
if (scope.$activeIndex >= matches.length) {
  scope.$activeIndex = options.autoSelect ? 0 : -1;
}
```

In my opinion `if (scope.$activeIndex >= matches.length)` is largely meaningless and a more acceptable behavior would be to reset the $activeIndex ANY time there is a call to $typeahead.update.

Current Behavior: 

I type 'foo' in the typeahead widget, get a set of 10 matches, use keyboard arrows to select the third match without actually pressing enter. I then delete 'foo' (using keyboard backspaces) and type 'bar' in the typeahead input field and the third match will be automatically selected.

Expected behavior: 

same as above except when I type 'bar' nothing gets selected until I choose to select it.

P.S. 

I did check that this change does not break any tests, but I think its a bit premature to use gulp 4.0 alpha considering it requires global changes to your dev environment. I had to uninstall my stable version of gulp and gulp-cli in order to confirm that my changes didnt break your test. I will need to uninstall the 4.0 alpha and reinstall my stable version to proceed with the rest of my development.
