### PR TITLE
Reset typeahead 'selection' through keyboard navigation

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -132,7 +132,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           }
 
           // Navigate with keyboard
-          else if (evt.keyCode === 38 && scope.$activeIndex > 0) scope.$activeIndex--;
+          else if (evt.keyCode === 38 && scope.$activeIndex >= 0) scope.$activeIndex--;
           else if (evt.keyCode === 40 && scope.$activeIndex < scope.$matches.length - 1) scope.$activeIndex++;
           else if (angular.isUndefined(scope.$activeIndex)) scope.$activeIndex = 0;
           scope.$digest();


### PR DESCRIPTION
Currently if you use arrows to select a match, there is no way to "unselect" since you can only set them to values between `0`(first match) and `$matches.length-1`(last match).

This change will allow you to reset your selection if you keyboard navigate higher than the first match -- which is a state where you start out before using up/down arrows. It does so by allowing $activeIndex range from `-1`(which is a default index when no selection took place) to `$matches.length-1`

I verified that no tests were broken
