### PR TITLE
fix(typeahead): work with mouse clicks in IE8

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -245,8 +245,12 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
           scope.$emit(options.prefixEvent + '.show', $tooltip);
         }
 
-        $tooltip.leave = function() {
+        $tooltip.leave = function(e) {
 
+          if(e.type == 'blur' && $(document.activeElement).parents().index($tooltip.$element) >= 0) {
+            $(e.target).focus();
+            return;
+          }
           clearTimeout(timeout);
           hoverState = 'out';
           if (!options.delay || !options.delay.hide) {


### PR DESCRIPTION
clicking on an element in a typeahead list in IE8 used to fail because the 'blur' event was getting triggered and the list was closing before the link click event got fired.
