### PR TITLE
bstimepicker: Force ability to update model for custom form validation

### DIFF
--- a/src/timepicker/docs/timepicker.demo.html
+++ b/src/timepicker/docs/timepicker.demo.html
@@ -276,6 +276,14 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
             <p>Sets the behavior of the arrow buttons in the picker. 'pager' to move the displayed hour/minute options, 'picker' to change the current time hours/minutes value.</p>
           </td>
         </tr>
+        <tr>
+          <td>overrideValidation</td>
+          <td>string</td>
+          <td>'false'</td>
+          <td>
+            <p>When set to true, provides a way to override internal validation, so anything typed into the form will update the view model.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -507,7 +507,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
           // If the model needs to be updated to matter what, these validation routines
           // can be overridden by setting the attribute overrideValidation eq true
-          if (defaults.overrideValidation){
+          if (defaults.overrideValidation === 'true'){
             return viewValue;
           } 
 

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -505,7 +505,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           // console.warn('$parser("%s"): viewValue=%o', element.attr('ng-model'), viewValue);
           var date;
 
-           // If the model needs to be updated to matter what, these validation routines
+          // If the model needs to be updated to matter what, these validation routines
           // can be overridden by setting the attribute overrideValidation eq true
           if (defaults.overrideValidation){
             return viewValue;
@@ -533,7 +533,6 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
             date = dateParser.timezoneOffsetAdjust(parsedTime, options.timezone, true);
             return formatDate(date, options.modelTimeFormat || options.timeFormat);
           }
-
           date = dateParser.timezoneOffsetAdjust(controller.$dateValue, options.timezone, true);
           if (options.timeType === 'number') {
             return date.getTime();
@@ -544,7 +543,6 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           } else {
             return new Date(date);
           }
-          
         });
 
         // modelValue -> $formatters -> viewValue

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -507,46 +507,43 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
 
            // If the model needs to be updated to matter what, these validation routines
           // can be overridden by setting the attribute overrideValidation eq true
-          if (!defaults.overrideValidation){
-
-            // Null values should correctly reset the model value & validity
-            if (!viewValue) {
-              // BREAKING CHANGE:
-              // return null (not undefined) when input value is empty, so angularjs 1.3
-              // ngModelController can go ahead and run validators, like ngRequired
-              controller.$setValidity('date', true);
-              return null;
-            }
-            var parsedTime = angular.isDate(viewValue) ? viewValue : dateParser.parse(viewValue, controller.$dateValue);
-            if (!parsedTime || isNaN(parsedTime.getTime())) {
-              controller.$setValidity('date', false);
-              // Return undefined, causes ngModelController to
-              // invalidate model value
-              return undefined;
-            } else {
-              validateAgainstMinMaxTime(parsedTime);
-            }
-
-            if (options.timeType === 'string') {
-              date = dateParser.timezoneOffsetAdjust(parsedTime, options.timezone, true);
-              return formatDate(date, options.modelTimeFormat || options.timeFormat);
-            }
-
-            date = dateParser.timezoneOffsetAdjust(controller.$dateValue, options.timezone, true);
-            if (options.timeType === 'number') {
-              return date.getTime();
-            } else if (options.timeType === 'unix') {
-              return date.getTime() / 1000;
-            } else if (options.timeType === 'iso') {
-              return date.toISOString();
-            } else {
-              return new Date(date);
-            }
-          } else {
+          if (defaults.overrideValidation){
             return viewValue;
+          } 
+
+          // Null values should correctly reset the model value & validity
+          if (!viewValue) {
+            // BREAKING CHANGE:
+            // return null (not undefined) when input value is empty, so angularjs 1.3
+            // ngModelController can go ahead and run validators, like ngRequired
+            controller.$setValidity('date', true);
+            return null;
+          }
+          var parsedTime = angular.isDate(viewValue) ? viewValue : dateParser.parse(viewValue, controller.$dateValue);
+          if (!parsedTime || isNaN(parsedTime.getTime())) {
+            controller.$setValidity('date', false);
+            // Return undefined, causes ngModelController to
+            // invalidate model value
+            return undefined;
+          } else {
+            validateAgainstMinMaxTime(parsedTime);
           }
 
-          
+          if (options.timeType === 'string') {
+            date = dateParser.timezoneOffsetAdjust(parsedTime, options.timezone, true);
+            return formatDate(date, options.modelTimeFormat || options.timeFormat);
+          }
+
+          date = dateParser.timezoneOffsetAdjust(controller.$dateValue, options.timezone, true);
+          if (options.timeType === 'number') {
+            return date.getTime();
+          } else if (options.timeType === 'unix') {
+            return date.getTime() / 1000;
+          } else if (options.timeType === 'iso') {
+            return date.toISOString();
+          } else {
+            return new Date(date);
+          }
           
         });
 


### PR DESCRIPTION
This feature allows developers to specify their own validation by essentially disabling the internal validation. It still passes through an instanceof Date when the bstimepicker control is used, but allows $watch to work in consuming controllers so one can offer manual validation of times such as is found in the following code: http://hastebin.com/ovocihuvip.vhdl

This change does not affect the normal operation of the bstimepicker directive.  It is purely a method to disable internal validation when a value is typed into the form.
