### PR TITLE
(datepicker): fix for IE 10 rendering of datepicker month selection mode

### DIFF
--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -18,7 +18,7 @@
         </button>
       </th>
     </tr>
-    <tr ng-show="showLabels" ng-bind-html="labels"></tr>
+    <tr ng-if="showLabels" ng-bind-html="labels"></tr>
   </thead>
   <tbody>
     <tr ng-repeat="(i, row) in rows" height="{{ 100 / rows.length }}%">


### PR DESCRIPTION
Switched rending of week labels to use `ng-if` instead of `ng-show` because IE 10 was incorrectly factoring in the hidden table row when calculating `table-layout: fixed`

Fixes #1801