### PR TITLE
fix(typeahead): add attribute autocomplete="off" instead of autocomplete="false"

### DIFF
--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -300,7 +300,7 @@ describe('typeahead', function () {
 
     it('should add the autocomplete attribute if one is not already present', function () {
       var elm = compileDirective('default');
-      expect(elm.attr('autocomplete')).toBe('false');
+      expect(elm.attr('autocomplete')).toBe('off');
     });
 
     it('should not change an already present autocomplete attribute', function () {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -217,7 +217,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
         });
 
         // Disable browser autocompletion
-        if (!element.attr('autocomplete')) element.attr('autocomplete', 'false');
+        if (!element.attr('autocomplete')) element.attr('autocomplete', 'off');
 
         // Build proper bsOptions
         var filter = options.filter || defaults.filter;


### PR DESCRIPTION
Fixes #1828