### PR TITLE
docs: update modal to reflect resolve/locals support, fixes #1845

### DIFF
--- a/src/modal/docs/modal.demo.html
+++ b/src/modal/docs/modal.demo.html
@@ -180,6 +180,22 @@
           </td>
         </tr>
         <tr>
+          <td>resolve</td>
+          <td>object</td>
+          <td>false</td>
+          <td>
+            <p>Object containing dependencies that will be injected into the controller's constructor when all the dependencies have resolved. The controller won't load if the promise is rejected.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>locals</td>
+          <td>object</td>
+          <td>false</td>
+          <td>
+            <p>Object containing dependencies that will be injected into the controller's constructor. Similar to resolve but expects literal values instead of promises.</p>
+          </td>
+        </tr>
+        <tr>
           <td>template</td>
           <td>string</td>
           <td>''</td>


### PR DESCRIPTION
https://github.com/mgcrea/angular-strap/commit/b272203f7704d2f66873d974beb20e4ac9fd4e7f added support for two awesome(IMO) features that aren't documented. `resolve` and `locals` allow you to pass data into your modal's controller so you can avoid passing things around on `$scope`. This simple PR adds those two definitions to the modal docs.