### PR TITLE
add phantomjs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-sauce-launcher": "^0.2.14",
     "ng-factory": "^1.0",
+    "phantomjs": "^1.9.18",
     "undertaker-lib-tasks": "^0.4.0"
   },
   "engines": {


### PR DESCRIPTION
NPM v3 does not install peer dependencies by default. `phantomjs` is a peer dependency of `karma-phantomjs-launcher`. SO, I can't run tests with NPM v3.

You can choose any version of it, but it should be mentioned into your package.json now.

Furthermore, see https://github.com/ng-tools/undertaker-lib-tasks/pull/1 this is another issue which doesn't allow me to build `angular-strap` with NPM v3