### PR TITLE
Fix(bsSelect): bsSelect should rerender when values inside arrays changes

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -321,14 +321,14 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Watch bsOptions values before filtering for changes
         var watchedOptions = parsedOptions.$match[7].replace(/\|.+/, '').trim();
-        scope.$watchCollection(watchedOptions, function(newValue, oldValue) {
+        scope.$watch(watchedOptions, function(newValue, oldValue) {
           // console.warn('scope.$watch(%s)', watchedOptions, newValue, oldValue);
           parsedOptions.valuesFn(scope, controller)
           .then(function(values) {
             select.update(values);
             controller.$render();
           });
-        });
+        }, true);
 
         // Watch model for changes
         scope.$watch(attr.ngModel, function(newValue, oldValue) {

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -233,6 +233,15 @@ describe('select', function () {
       expect(sandboxEl.find('.dropdown-menu li').length).toBe(scope.icons.length);
       expect(sandboxEl.find('.dropdown-menu li:eq(0)').text().trim()).toBe(scope.icons[0].label);
     });
+    
+    it('should correctly watch for changes for elements in arrays', function() {
+      var elm = compileDirective('default');
+      scope.icons[0].label = scope.icons[0].label + "s" 
+      scope.$digest();
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.dropdown-menu li').length).toBe(scope.icons.length);
+      expect(sandboxEl.find('.dropdown-menu li:eq(0)').text().trim()).toBe(scope.icons[0].label);
+    });
 
     it('should support bsOptions with filters', function() {
       var elm = compileDirective('markup-bsOptions-filtered');


### PR DESCRIPTION
Change bsSelect to deep watch bsOptions values.

Didn't know if this is a fix or a feature. So i decided to call it a fix. 
Will gladly rebase.

fixes #1833