### PR TITLE
fix opening dropdown with custom template

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -60,7 +60,7 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
 
         var show = $dropdown.show;
         $dropdown.show = function() {
-          if(!scope.content) return;
+          if(this.$options.templateUrl === defaults.templateUrl && !scope.content) return;
           show();
           // use timeout to hookup the events to prevent
           // event bubbling from being processed imediately.


### PR DESCRIPTION
Hello,
after #1891  dropdowns could not be opened without content property on scope. However, custom templates will probably have another variables to bind, instead of $scope.content.
  