### PR TITLE
fix(dateParser): ignore regex special characters inside literals

### DIFF
--- a/src/helpers/date-parser.js
+++ b/src/helpers/date-parser.js
@@ -240,7 +240,8 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
       }
 
       function buildDateAbstractRegex(format) {
-        var escapedLiteralFormat = format.replace(/''/g, '\\\'');
+        var escapedFormat = escapeReservedSymbols(format);
+        var escapedLiteralFormat = escapedFormat.replace(/''/g, '\\\'');
         var literalRegex = /('(?:\\'|.)*?')/;
         var formatParts = escapedLiteralFormat.split(literalRegex);
         var dateElements = Object.keys(regExpMap);
@@ -260,6 +261,19 @@ angular.module('mgcrea.ngStrap.helpers.dateParser', [])
         });
 
         return dateRegexParts.join('');
+      }
+
+      function escapeReservedSymbols(text) {
+        return text.replace(/\\/g, '[\\\\]')
+                   .replace(/-/g, '[-]')
+                   .replace(/\./g, '[.]')
+                   .replace(/\*/g, '[*]')
+                   .replace(/\+/g, '[+]')
+                   .replace(/\?/g, '[?]')
+                   .replace(/\$/g, '[$]')
+                   .replace(/\^/g, '[^]')
+                   .replace(/\//g, '[/]')
+                   .replace(/\\s/g, '[\\s]');
       }
 
       function isFormatStringLiteral(text) {

--- a/src/helpers/test/date-parser.spec.js
+++ b/src/helpers/test/date-parser.spec.js
@@ -432,6 +432,13 @@ describe('dateParser', function() {
         expect(parser.isValid('Wednesday.01/2014')).toBe(true);
       });
 
+      it('should ignore literal contents', function() {
+        parser = $dateParser({format: '\'.+*?\\$^\' EEEE.d/y'});
+        var testString = '.+*?\\$^ Wednesday.01/2014';
+        expect(parser.isValid(testString)).toBe(true);
+        expect(parser.parse(testString)).toEqual(new Date(2014, 0, 1, 0, 0, 0));
+      });
+
       generateTestCasesForParsing([
         {val: 'Wednesday.01/2014', expect: new Date(2014, 0, 1, 0, 0, 0), reason: 'format string with escaped literal'}
       ]);


### PR DESCRIPTION
Re-added a modified escapeReservedSymbols to support special regex characters inside the format string. Don't know what characters should be supported, I added some of the most used in regex, besides the ones that already existed.
This will probably only be relevant for very special edge cases.