### PR TITLE
feat(modal): set incremental z-index value for modals and asides to allow for stacking

### DIFF
--- a/src/aside/test/aside.spec.js
+++ b/src/aside/test/aside.spec.js
@@ -256,6 +256,28 @@ describe('aside', function () {
         expect(bodyEl.find('.aside-backdrop').length).toBe(0);
       });
 
+      it('should show backdrop above a previous aside dialog using the z-index value', function() {
+        var elm1 = compileDirective('default');
+        var elm2 = compileDirective('default');
+
+        expect(bodyEl.find('.aside-backdrop').length).toBe(0);
+
+        angular.element(elm1[0]).triggerHandler('click');
+        expect(bodyEl.find('.aside-backdrop').length).toBe(1);
+        var backdrop1 = bodyEl.find('.aside-backdrop')[0];
+        var aside1 = bodyEl.find('.aside')[0];
+
+        angular.element(elm2[0]).triggerHandler('click');
+        expect(bodyEl.find('.aside-backdrop').length).toBe(2);
+        var backdrop2 = bodyEl.find('.aside-backdrop')[0];
+        var aside2 = bodyEl.find('.aside')[1];
+
+        expect(angular.element(backdrop1).css('z-index')).toBe('1040');
+        expect(angular.element(aside1).css('z-index')).toBe('1050');
+        expect(angular.element(backdrop2).css('z-index')).toBe('1060');
+        expect(angular.element(aside2).css('z-index')).toBe('1070');
+      });
+
     });
 
     describe('keyboard', function() {

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -197,8 +197,10 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
         $modal.hide = function() {
           if(!$modal.$isShown) return;
 
-          // decrement number of modals
-          backdropCount--;
+          if(options.backdrop) {
+              // decrement number of modals
+              backdropCount--;
+          }
 
           if(scope.$emit(options.prefixEvent + '.hide.before', $modal).defaultPrevented) {
             return;

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -28,8 +28,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       var requestAnimationFrame = $window.requestAnimationFrame || $window.setTimeout;
       var bodyElement = angular.element($window.document.body);
 
-      var modalCount = 0;
-      var baseZindexValue = 1037;
+      var backdropCount = 0;
+      var dialogBaseZindex = 1050;
+      var backdropBaseZindex = 1040;
 
       function ModalFactory(config) {
 
@@ -76,7 +77,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
         // Fetch, compile then initialize modal
         var compileData, modalElement, modalScope;
         var backdropElement = angular.element('<div class="' + options.prefixClass + '-backdrop"/>');
-        backdropElement.css({position:'fixed', top:'0px', left:'0px', bottom:'0px', right:'0px', 'z-index': 1038});
+        backdropElement.css({position:'fixed', top:'0px', left:'0px', bottom:'0px', right:'0px'});
         promise.then(function(data) {
           compileData = data;
           $modal.init();
@@ -134,12 +135,14 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
           // Fetch a cloned element linked from template (noop callback is required)
           modalElement = $modal.$element = compileData.link(modalScope, function(clonedElement, scope) {});
 
-          // increment number of modals
-          modalCount++;
+          if(options.backdrop) {
+              // set z-index
+              modalElement.css({'z-index': dialogBaseZindex + (backdropCount * 20)});
+              backdropElement.css({'z-index': backdropBaseZindex + (backdropCount * 20)});
 
-          // set z-index
-          modalElement.css({'z-index': baseZindexValue + modalCount});
-          backdropElement.css({'z-index': baseZindexValue + modalCount});
+              // increment number of backdrops
+              backdropCount++;
+          }
 
           if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
             return;
@@ -195,7 +198,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
           if(!$modal.$isShown) return;
 
           // decrement number of modals
-          modalCount--;
+          backdropCount--;
 
           if(scope.$emit(options.prefixEvent + '.hide.before', $modal).defaultPrevented) {
             return;

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -28,6 +28,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       var requestAnimationFrame = $window.requestAnimationFrame || $window.setTimeout;
       var bodyElement = angular.element($window.document.body);
 
+      var modalCount = 0;
+      var baseZindexValue = 1037;
+
       function ModalFactory(config) {
 
         var $modal = {};
@@ -131,6 +134,13 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
           // Fetch a cloned element linked from template (noop callback is required)
           modalElement = $modal.$element = compileData.link(modalScope, function(clonedElement, scope) {});
 
+          // increment number of modals
+          modalCount++;
+
+          // set z-index
+          modalElement.css({'z-index': baseZindexValue + modalCount});
+          backdropElement.css({'z-index': baseZindexValue + modalCount});
+
           if(scope.$emit(options.prefixEvent + '.show.before', $modal).defaultPrevented) {
             return;
           }
@@ -183,6 +193,9 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         $modal.hide = function() {
           if(!$modal.$isShown) return;
+
+          // decrement number of modals
+          modalCount--;
 
           if(scope.$emit(options.prefixEvent + '.hide.before', $modal).defaultPrevented) {
             return;

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -671,6 +671,28 @@ describe('modal', function() {
         expect(bodyEl.find('.modal-backdrop').length).toBe(0);
       });
 
+      it('should show backdrop above a previous modal dialog using the z-index value', function() {
+        var elm1 = compileDirective('default');
+        var elm2 = compileDirective('default');
+
+        expect(bodyEl.find('.modal-backdrop').length).toBe(0);
+
+        angular.element(elm1[0]).triggerHandler('click');
+        expect(bodyEl.find('.modal-backdrop').length).toBe(1);
+        var backdrop1 = bodyEl.find('.modal-backdrop')[0];
+        var modal1 = bodyEl.find('.modal')[0];
+
+        angular.element(elm2[0]).triggerHandler('click');
+        expect(bodyEl.find('.modal-backdrop').length).toBe(2);
+        var backdrop2 = bodyEl.find('.modal-backdrop')[0];
+        var modal2 = bodyEl.find('.modal')[1];
+
+        expect(angular.element(backdrop1).css('z-index')).toBe('1040');
+        expect(angular.element(modal1).css('z-index')).toBe('1050');
+        expect(angular.element(backdrop2).css('z-index')).toBe('1060');
+        expect(angular.element(modal2).css('z-index')).toBe('1070');
+      });
+
     });
 
 


### PR DESCRIPTION
feat(modal): set incremental z-index value for modals and asides to allow for stacking

The number of active modals and asides are tracked in order to set a `z-index` value that will allow those elements to be on top of each other.
Currently, if two asides are shown at the same time, clicking the backdrop will hide the aside that is below the one above.  Also, the backdrop of the second aside is below the first aside.