### PR TITLE
fix(dropdown): ng-repeat problem with replaced array

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -156,10 +156,23 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
           // Garbage collection
           scope.$on('$destroy', function() {
             if (dropdown) dropdown.destroy();
-            options = null;
             dropdown = null;
           });
 
+          //Garbage collection of options
+          if (!options.compileDestroy) {
+            options.compileDestroy = function(compileScope) {
+              while (scope.$parent) {
+                scope = scope.$parent;
+                if ('$index' in scope) {
+                  compileScope = scope.$parent;
+                }
+              }
+              return compileScope;
+            }(scope).$on('$destroy', function() {
+              options = null;
+            });
+          }
         };
       }
     };


### PR DESCRIPTION
Dropdown breaks inside ng-repeat whenever the array driving the ng-repeat gets replaced with a new one. Compile only gets called once in this case, but scope.$destroy gets called whenever the rows get deleted and replaced by ng-repeat - options gets set to null, and all subsequent calls to postlink log an error. 

This fix finds the topmost scope containing $index, and uses its parent. If none is found then the current scope is used. A $destroy listener is attached to that scope (at most once) to set options to null.