### PR TITLE
Angular 1.4.7 fix filter:notarray

### DIFF
--- a/dist/angular-strap.js
+++ b/dist/angular-strap.js
@@ -708,6 +708,9 @@
           return $filter('filter')(results, expression, comparator);
         });
       } else {
+        if (typeof array !== 'array') {
+          array = [];
+        }
         return $filter('filter')(array, expression, comparator);
       }
     };


### PR DESCRIPTION
Connected with this issue:
https://github.com/mgcrea/angular-strap/issues/1567

When I switch from angular 1.3.15 to 1.4.7 i saw that i got error like this:

Error: [filter:notarray] Expected array but received: false

So i propose to add this simple fix to avoid it.

Best regards