### PR TITLE
reversed calculation for top and bottom - fixed

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -357,10 +357,10 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
             var originalPlacement = placement;
             var viewportPosition = getPosition($tooltip.$viewport);
 
-            if (/top/.test(originalPlacement) && elementPosition.bottom + tipHeight > viewportPosition.bottom) {
-              placement = originalPlacement.replace('top', 'bottom');
-            } else if (/bottom/.test(originalPlacement) && elementPosition.top - tipHeight < viewportPosition.top) {
+            if (/bottom/.test(originalPlacement) && elementPosition.bottom + tipHeight > viewportPosition.bottom) {
               placement = originalPlacement.replace('bottom', 'top');
+            } else if (/top/.test(originalPlacement) && elementPosition.top - tipHeight < viewportPosition.top) {
+              placement = originalPlacement.replace('top', 'bottom');
             }
 
             if (/left/.test(originalPlacement) && elementPosition.left - tipWidth < viewportPosition.left) {


### PR DESCRIPTION
When calculating the position for auto 'top' and auto 'bottom' of the $tooltip.$applyPlacement it looks that the code it dealing the opposite direction for top and bottom.
tested it on bsDropDown and it works good.
