### PR TITLE
feat(modal): support CSS class on modal element

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -18,7 +18,8 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       backdrop: true,
       keyboard: true,
       html: false,
-      show: true
+      show: true,
+      modalClass: false
     };
 
     this.$get = function($window, $rootScope, $bsCompiler, $animate, $timeout, $sce, dimensions) {
@@ -150,6 +151,10 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
           // Set the initial positioning.
           modalElement.css({display: 'block'}).addClass(options.placement);
+
+          if(options.modalClass) {
+            modalElement.addClass(options.modalClass);
+          }
 
           // Options: animation
           if(options.animation) {
@@ -340,7 +345,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass'], function(key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass', 'modalClass'], function(key) {
           if(angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -94,6 +94,9 @@ describe('modal', function() {
     'options-contentTemplate': {
       scope: {modal: {title: 'Title', content: 'Hello Modal!', counter: 0}, items: ['foo', 'bar', 'baz']},
       element: '<a title="{{modal.title}}" data-content="{{modal.content}}" data-content-template="custom" bs-modal>click me</a>'
+    },
+    'options-modalClass': {
+      element: '<a bs-modal="modal" data-modal-class="my-custom-class">click me</a>'
     }
   };
 
@@ -695,6 +698,19 @@ describe('modal', function() {
 
     });
 
+    describe('modalClass', function() {
+      it('should add class to the modal element', function() {
+        var elm = compileDirective('options-modalClass');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.children('.modal')).toHaveClass('my-custom-class');
+      });
+
+      it('should not add class to the modal element when modalClass is not present', function() {
+        var elm = compileDirective('default');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.children('.modal')).not.toHaveClass('my-custom-class');
+      });
+    });
 
   });
 


### PR DESCRIPTION
Add ‘modalClass' as an option on the modal configuration. When specified, the string will be added as a CSS class to the outer modal element. If the option isn’t specified, no class is added.

Closes #1331