### PR TITLE
fix(dropdown) prevent null pointer exception w/o inline template

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -116,7 +116,7 @@ angular.module('mgcrea.ngStrap.dropdown', ['mgcrea.ngStrap.tooltip'])
           while (nextSibling && nextSibling.nodeType !== 1) {
             nextSibling = nextSibling.nextSibling;
           }
-          if (nextSibling.classList.contains('dropdown-menu')) {
+          if (nextSibling && nextSibling.classList.contains('dropdown-menu')) {
             tAttrs.template = nextSibling.outerHTML;
             tAttrs.templateUrl = undefined;
             nextSibling.parentNode.removeChild(nextSibling);


### PR DESCRIPTION
Prevent a null pointer exception when overriding the default template while using the dropdown without setting the `bs-dropdown` attribute.

```html
<div bs-dropdown data-template-url="something.html" />
```