### PR TITLE
feat(modal): support modal size option

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -166,7 +166,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
           }
 
           // Options: size
-          if(options.size && validSizes[options.size]) {
+          if (options.size && validSizes[options.size]) {
             angular.element(findElement('.modal-dialog', modalElement[0])).addClass(validSizes[options.size]);
           }
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -19,7 +19,8 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       backdrop: true,
       keyboard: true,
       html: false,
-      show: true
+      show: true,
+      size: null
     };
 
     this.$get = function ($window, $rootScope, $bsCompiler, $animate, $timeout, $sce, dimensions) {
@@ -31,6 +32,11 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       var backdropCount = 0;
       var dialogBaseZindex = 1050;
       var backdropBaseZindex = 1040;
+
+      var validSizes = {
+        lg: 'modal-lg',
+        sm: 'modal-sm'
+      };
 
       function ModalFactory(config) {
 
@@ -157,6 +163,11 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
           // Options: customClass
           if (options.customClass) {
             modalElement.addClass(options.customClass);
+          }
+
+          // Options: size
+          if(options.size && validSizes[options.size]) {
+            angular.element(findElement('.modal-dialog', modalElement[0])).addClass(validSizes[options.size]);
           }
 
           // Options: animation
@@ -356,7 +367,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass', 'customClass', 'modalClass'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass', 'customClass', 'modalClass', 'size'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -97,7 +97,13 @@ describe('modal', function() {
     },
     'options-modalClass': {
       element: '<a bs-modal="modal" data-modal-class="my-custom-class">click me</a>'
-    }
+    },
+    'options-size-lg': {
+      element: '<a bs-modal="modal" data-size="lg">click me</a>'
+    },
+    'options-size-invalid': {
+      element: '<a bs-modal="modal" data-size="md">click me</a>'
+    },
   };
 
   function compileDirective(template, locals) {
@@ -710,6 +716,27 @@ describe('modal', function() {
         angular.element(elm[0]).triggerHandler('click');
         expect(sandboxEl.children('.modal')).not.toHaveClass('my-custom-class');
       });
+    });
+
+    describe('size', function() {
+      it('sets size class when specified', function() {
+        var elm = compileDirective('options-size-lg');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.find('.modal-dialog')).toHaveClass('modal-lg');
+      });
+
+      it('does not set size class when not specified', function() {
+        var elm = compileDirective('default');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.find('.modal-dialog')).not.toHaveClass('modal-lg');
+      });
+
+      it('does not set size class when invalid size is specified', function() {
+        var elm = compileDirective('options-size-invalid');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.find('.modal-dialog')).not.toHaveClass('modal-lg');
+      });
+
     });
 
   });


### PR DESCRIPTION
Add the `size` option for modals, which supports “sm” and “lg” as values. These correspond to Bootstrap’s pre-configured “modal-sm” and “modal-lg” classes.