### PR TITLE
fix(popover): fix popover title (fixes #2022)

### DIFF
--- a/src/helpers/compiler.js
+++ b/src/helpers/compiler.js
@@ -106,13 +106,25 @@ function bsCompilerService($q, $http, $injector, $compile, $controller, $templat
       throw new Error('Missing `template` / `templateUrl` option.');
     }
 
+    if (options.titleTemplate) {
+      resolve.$template = $q.all([resolve.$template, fetchTemplate(options.titleTemplate)])
+        .then(function (templates) {
+          var templateEl = angular.element(templates[0]);
+          findElement('[ng-bind="title"]', templateEl[0])
+            .removeAttr('ng-bind')
+            .html(templates[1]);
+          return templateEl[0].outerHTML;
+        });
+    }
+
     if (options.contentTemplate) {
       // TODO(mgcrea): deprecate?
       resolve.$template = $q.all([resolve.$template, fetchTemplate(options.contentTemplate)])
         .then(function (templates) {
           var templateEl = angular.element(templates[0]);
-          var contentEl = findElement('[ng-bind="content"], [ng-bind="title"]', templateEl[0])
-            .removeAttr('ng-bind').html(templates[1]);
+          var contentEl = findElement('[ng-bind="content"]', templateEl[0])
+            .removeAttr('ng-bind')
+            .html(templates[1]);
           // Drop the default footer as you probably don't want it if you use a custom contentTemplate
           if (!options.templateUrl) contentEl.next().remove();
           return templateEl[0].outerHTML;

--- a/src/popover/test/popover.spec.js
+++ b/src/popover/test/popover.spec.js
@@ -93,6 +93,10 @@ describe('popover', function () {
     'bsShow-binding': {
       scope: {isVisible: false, popover: {title: 'Title', content: 'Hello Popover!'}},
       element: '<a class="btn" title="{{popover.title}}" data-content="{{popover.content}}" bs-popover bs-show="isVisible"></a>'
+    },
+    'options-contentTemplate': {
+      scope: {foo: 'bar'},
+      element: '<a class="btn" title="foo-title" data-content-template="custom" bs-popover bs-show="isVisible"></a>'
     }
   };
 
@@ -317,7 +321,7 @@ describe('popover', function () {
         expect(sandboxEl.find('.popover-content').html()).toBe(scope.popover.content);
       });
 
-      it('should NOT correctly compile inner content when truthy', function() {
+      it('should NOT correctly compile inner content when falsy', function() {
         var elm = compileDirective('options-html', {html: 'false'});
         angular.element(elm[0]).triggerHandler('click');
         expect(sandboxEl.find('.popover-title').html()).not.toBe(scope.popover.title);
@@ -389,6 +393,19 @@ describe('popover', function () {
         angular.element(elm[0]).triggerHandler('click');
         expect(angular.element(sandboxEl.find('.popover-content > .btn')[0]).triggerHandler('click'));
         expect(scope.popover.counter).toBe(2);
+      });
+
+    });
+
+
+    describe('contentTemplate', function () {
+
+      it('should support custom content templates', function() {
+        $templateCache.put('custom', '{{foo}}: some content inside the template');
+        var elm = compileDirective('options-contentTemplate');
+        angular.element(elm[0]).triggerHandler('click');
+        expect(sandboxEl.find('.popover-title').text()).toBe('foo-title');
+        expect(sandboxEl.find('.popover-content').text()).toBe('bar: some content inside the template');
       });
 
     });

--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -154,7 +154,7 @@
           </td>
         </tr>
         <tr>
-          <td>contentTemplate</td>
+          <td>titleTemplate</td>
           <td>path</td>
           <td>false</td>
           <td>

--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -170,9 +170,9 @@ describe('tooltip', function() {
       scope: {tooltip: {title: 'Hello Tooltip!', counter: 0}, items: ['foo', 'bar', 'baz']},
       element: '<a title="{{tooltip.title}}" data-template-url="custom" bs-tooltip>hover me</a>'
     },
-    'options-contentTemplate': {
+    'options-titleTemplate': {
       scope: {tooltip: {title: 'Hello Tooltip!', counter: 0}, items: ['foo', 'bar', 'baz']},
-      element: '<a title="{{tooltip.title}}" data-content-template="custom" bs-tooltip>hover me</a>'
+      element: '<a title="{{tooltip.title}}" data-title-template="custom" bs-tooltip>hover me</a>'
     },
     'bsShow-attr': {
       scope: {tooltip: {title: 'Hello Tooltip!'}},
@@ -913,11 +913,11 @@ describe('tooltip', function() {
 
     });
 
-    describe('contentTemplate', function() {
+    describe('titleTemplate', function() {
 
-      it('should support custom contentTemplate', function() {
+      it('should support custom titleTemplate', function() {
         $templateCache.put('custom', 'foo: {{title}}');
-        var elm = compileDirective('options-contentTemplate');
+        var elm = compileDirective('options-titleTemplate');
         angular.element(elm[0]).triggerHandler('mouseenter');
          expect(sandboxEl.find('.tooltip-inner').text()).toBe('foo: ' + scope.tooltip.title);
       });

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -14,7 +14,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
       placement: 'top',
       templateUrl: 'tooltip/tooltip.tpl.html',
       template: '',
-      contentTemplate: false,
+      titleTemplate: false,
       trigger: 'hover focus',
       keyboard: false,
       html: false,
@@ -739,7 +739,7 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
         var tooltip;
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'backdropAnimation', 'type', 'customClass', 'id'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'titleTemplate', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'backdropAnimation', 'type', 'customClass', 'id'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 


### PR DESCRIPTION
The change in #2007 overrides all "title"-bindings with the contentTemplate. This fix renames the contentTemplate-attribute for bs-tooltip to titleTemplate, so that the name clash with the title of bs-popover is solved.

Breaking change: the contentTemplate-attribute for tooltips has been renamed to titleTemplate.