### PR TITLE
Scrollspy: processing of $destroy is incorrect.

### DIFF
--- a/src/scrollspy/scrollspy.js
+++ b/src/scrollspy/scrollspy.js
@@ -191,7 +191,7 @@ angular.module('mgcrea.ngStrap.scrollspy', ['mgcrea.ngStrap.helpers.debounce', '
               break;
             }
           }
-          trackedElements = trackedElements.splice(toDelete, 1);
+          trackedElements.splice(toDelete, 1);
         };
 
         $scrollspy.activate = function (i) {


### PR DESCRIPTION
Behavior of splice method:
  An array containing the deleted elements If only one element is removed, an array of one element is returned.

and splice method is destructive.

refs: JS splice method
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/splice