### PR TITLE
fixed install error of phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sauce-launcher": "^0.3.0",
     "ng-factory": "^1.1.0",
-    "phantomjs": "^2.1.3",
     "phantomjs-prebuilt": "^2.1.4",
     "through2": "^2.0.1",
     "undertaker-lib-tasks": "^0.5.3"


### PR DESCRIPTION
`phantomjs-prebuilt` wants to make symlink for compatible with `phantomjs`, but
the destination is already exist.

Error:
https://travis-ci.org/mgcrea/angular-strap/jobs/118524444#L1383