### PR TITLE
fix(typeahead): check if value is defined instead of boolean check

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -283,7 +283,7 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
 
           // If there's no display value, attempt to use the modelValue.
           // If the model is an object not much we can do
-          if (modelValue && typeof modelValue !== 'object') {
+          if (angular.isDefined(modelValue) && typeof modelValue !== 'object') {
             return modelValue;
           }
           return '';


### PR DESCRIPTION
When the typeahead is first rendered, it checks if there is a `modelValue`
to show.  It does this by `if(modelValue && ...)`. if modelValue is false or 0,
it will not populate the typeahead display.  By checking if it is defined instead,
then it will accept 0 as a value.

closes #2053