### PR TITLE
fix(select): fix popover not closing when click on select button on a touch screen

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -32,7 +32,8 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
 
     this.$get = function ($window, $rootScope, $bsCompiler, $q, $templateCache, $http, $animate, $sce, dimensions, $$rAF, $timeout) {
 
-      var isTouch = 'createTouch' in $window.document;
+      var isNative = /(ip[ao]d|iphone|android)/ig.test($window.navigator.userAgent);
+      var isTouch = ('createTouch' in $window.document) && isNative;
       var $body = angular.element($window.document);
 
       function TooltipFactory (element, config) {


### PR DESCRIPTION
When you click the button, it correctly shows the list but if you click it again, it does not hide the list. However if you are using the touch event it is working correctly. On a non-touchscreen computer, the behavior is the correct one too.
Now the touch event is activated for mobile devices

closes: #2052 