### PR TITLE
fix(typeahead): stop the cursor from jumping to the end of the input upon refocus

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -301,7 +301,10 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           var selected = index !== -1 ? typeahead.$scope.$matches[index].label : controller.$viewValue;
           selected = angular.isObject(selected) ? parsedOptions.displayValue(selected) : selected;
           var value = selected ? selected.toString().replace(/<(?:.|\n)*?>/gm, '') : '';
+          var ss = element[0].selectionStart;
+          var sd = element[0].selectionEnd;
           element.val(options.trimValue === false ? value : value.trim());
+          element[0].setSelectionRange(ss, sd);
         };
 
         // Garbage collection


### PR DESCRIPTION
currently, when finishing text input, blur then focus and begin typing at another point
in the text (e.g. the beginning), the cursor will move to the end of the text after
inserting a new character.
now, the cursor will move to after the new character typed (normal behaviour)

closes: #1083 #1837 #1448 