### PR TITLE
Modify tab template to allow keyboard navigation.

### DIFF
--- a/src/tab/tab.tpl.html
+++ b/src/tab/tab.tpl.html
@@ -1,6 +1,6 @@
 <ul class="nav" ng-class="$navClass" role="tablist">
   <li role="presentation" ng-repeat="$pane in $panes track by $index" ng-class="[ $isActive($pane, $index) ? $activeClass : '', $pane.disabled ? 'disabled' : '' ]">
-    <a role="tab" data-toggle="tab" ng-click="!$pane.disabled && $setActive($pane.name || $index)" data-index="{{ $index }}" ng-bind-html="$pane.title" aria-controls="$pane.title"></a>
+    <a role="tab" data-toggle="tab" ng-click="!$pane.disabled && $setActive($pane.name || $index)" data-index="{{ $index }}" ng-bind-html="$pane.title" aria-controls="$pane.title" href=""></a>
   </li>
 </ul>
 <div ng-transclude class="tab-content">


### PR DESCRIPTION
Adding an empty href to the _a_ tag for tab headers allows keyboard navigation to the links (ie using tab) without changing functionality. Necessary to comply with WCAG 2.1 (https://www.w3.org/TR/UNDERSTANDING-WCAG20/keyboard-operation.html) and more in line with the w3c convention for hyperlinks (http://w3c.github.io/html-reference/a.html#a.attrs.href). 