### PR TITLE
fix(select): don't attempt to select when tab is pressed and no item is selected

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -113,6 +113,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         };
 
         $select.select = function (index) {
+          if (angular.isUndefined(index) || index < 0 || index >= scope.$matches.length) { return; }
           var value = scope.$matches[index].value;
           scope.$apply(function () {
             $select.activate(index);

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -203,6 +203,15 @@ describe('select', function () {
       expect(sandboxEl.find('.dropdown-menu li:eq(0)')).toHaveClass('active');
     });
 
+    it('should not attempt to select an item when there is none highlighted and tab is pressed', function() {
+      var elm = compileDirective('default');
+      angular.element(elm[0]).triggerHandler('focus');
+      expect(sandboxEl.find('.active').length).toBe(0);
+      $timeout.flush();
+      triggerKeyDown( elm, 9 );
+      expect(sandboxEl.find('.active').length).toBe(0);
+    });
+
   });
 
   describe('when model has no initial selection', function() {


### PR DESCRIPTION
Currently, when tab is pressed to get to a new input from `bs-select`, the `bs-select` will
close and fire `$select.select()`.  If an item isn't select, this will be `undefined` and throw an `Error`.
Now, there is a check that the index of the item to be selected isn't undefined or outside
the bounds of the `$matches`.

closes: #1857