### PR TITLE
feat(select): allow single-selection bs-select to be toggled

### DIFF
--- a/src/select/docs/select.demo.html
+++ b/src/select/docs/select.demo.html
@@ -23,7 +23,7 @@ $scope.icons = {{icons}};
   <div class="bs-example" style="padding-bottom: 24px;" append-source>
 
     <label>Single select:&nbsp;</label>
-    <button type="button" class="btn btn-default" ng-model="selectedIcon" data-html="1" bs-options="icon.value as icon.label for icon in icons" bs-select>
+    <button type="button" class="btn btn-default" ng-model="selectedIcon" data-html="1" data-toggle="true" bs-options="icon.value as icon.label for icon in icons" bs-select>
       Action <span class="caret"></span>
     </button>
     <hr>
@@ -125,6 +125,14 @@ $scope.icons = {{icons}};
           <td>'$select'</td>
           <td>
             <p>If provided, overrides the default template, can be either a remote URL or a cached template id.</p>
+          </td>
+        </tr>
+        <tr>
+          <td>toggle</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>When true, an item can be deselected.</p>
           </td>
         </tr>
         <tr>

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -24,7 +24,8 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
       noneText: 'None',
       maxLength: 3,
       maxLengthHtml: 'selected',
-      iconCheckmark: 'glyphicon glyphicon-ok'
+      iconCheckmark: 'glyphicon glyphicon-ok',
+      toggle: false
     };
 
     this.$get = function ($window, $document, $rootScope, $tooltip, $timeout) {
@@ -124,7 +125,11 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
                 return scope.$matches[index].value;
               }));
             } else {
-              controller.$setViewValue(value);
+              if (options.toggle) {
+                controller.$setViewValue((value === controller.$modelValue) ? undefined : value);
+              } else {
+                controller.$setViewValue(value);
+              }
               // Hide if single select
               $select.hide();
             }
@@ -283,7 +288,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent', 'toggle'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -47,6 +47,10 @@ describe('select', function () {
       scope: {selectedIcon: '', icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
       element: '<button id="select1" type="button" class="btn" ng-model="selectedIcon" bs-options="icon.value as icon.label for icon in icons" bs-select></button>'
     },
+    'default-toggle': {
+      scope: {selectedIcon: '', icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
+      element: '<button type="button" class="btn" ng-model="selectedIcon" bs-options="icon.value as icon.label for icon in icons" data-toggle="true" bs-select></button>'
+    },
     'markup-ngRepeat': {
       element: '<ul><li ng-repeat="i in [1, 2, 3]"><button type="button" class="btn" ng-model="selectedIcon" bs-options="icon.value as icon.label for icon in icons" bs-select></button></li></ul>'
     },
@@ -744,6 +748,28 @@ describe('select', function () {
       angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
 
       expect(id).toBe('select1');
+    });
+  });
+
+  describe('toggle', function () {
+
+    it('should allow user to toggle a selection', function() {
+        var elm = compileDirective('default-toggle');
+        angular.element(elm[0]).triggerHandler('focus');
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcon).toBe(scope.icons[1].value);
+        angular.element(elm[0]).triggerHandler('focus');
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcon).toBe(undefined);
+    });
+
+    it('should not allow user to toggle a selection', function() {
+        var elm = compileDirective('default');
+        angular.element(elm[0]).triggerHandler('focus');
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcon).toBe(scope.icons[1].value);
+        angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
+        expect(scope.selectedIcon).toBe(scope.icons[1].value);
     });
   });
 });


### PR DESCRIPTION
Currently, when a `bs-select` is allowed one selection, you cannot
deselect your chosen item.

Now, you can provide an option where if you click the selected item, it will now deselect.

closes #1756