### PR TITLE
Fix issue of leading space when title is not given in $alert

### DIFF
--- a/src/alert/alert.js
+++ b/src/alert/alert.js
@@ -1,8 +1,6 @@
 'use strict';
 
 // @BUG: following snippet won't compile correctly
-// @TODO: submit issue to core
-// '<span ng-if="title"><strong ng-bind="title"></strong>&nbsp;</span><span ng-bind-html="content"></span>' +
 
 angular.module('mgcrea.ngStrap.alert', ['mgcrea.ngStrap.modal'])
 

--- a/src/alert/alert.tpl.html
+++ b/src/alert/alert.tpl.html
@@ -1,4 +1,7 @@
 <div class="alert" ng-class="[type ? 'alert-' + type : null]">
   <button type="button" class="close" ng-if="dismissable" ng-click="$hide()">&times;</button>
-  <strong ng-bind="title"></strong>&nbsp;<span ng-bind-html="content"></span>
+  <span ng-if="title">
+    <strong ng-bind="title"></strong>&nbsp;<span ng-bind-html="content"></span>
+  </span>
+  <span ng-if="!title" ng-bind-html="content"></span>
 </div>

--- a/src/alert/test/alert.spec.js
+++ b/src/alert/test/alert.spec.js
@@ -107,29 +107,29 @@ describe('alert', function() {
     it('should correctly compile inner content', function() {
       var elm = compileDirective('default');
       angular.element(elm[0]).triggerHandler('click');
-      expect(sandboxEl.find('.alert > strong').html()).toBe(scope.alert.title);
-      expect(sandboxEl.find('.alert > span').html()).toBe(scope.alert.content);
+      expect(sandboxEl.find('.alert strong').html()).toBe(scope.alert.title);
+      expect(sandboxEl.find('.alert').html()).toContain(scope.alert.content);
     });
 
     it('should support scope as object', function() {
       var elm = compileDirective('markup-scope');
       angular.element(elm[0]).triggerHandler('click');
-      expect(sandboxEl.find('.alert > strong').html()).toBe(scope.alert.title);
-      expect(sandboxEl.find('.alert > span').html()).toBe(scope.alert.content);
+      expect(sandboxEl.find('.alert strong').html()).toBe(scope.alert.title);
+      expect(sandboxEl.find('.alert').html()).toContain(scope.alert.content);
     });
 
     it('should support ngRepeat markup inside', function() {
       var elm = compileDirective('markup-ngRepeat');
       angular.element(elm.find('[bs-alert]')).triggerHandler('click');
-      expect(sandboxEl.find('.alert > strong').html()).toBe(scope.items[0].alert.title);
-      expect(sandboxEl.find('.alert > span').html()).toBe(scope.items[0].alert.content);
+      expect(sandboxEl.find('.alert strong').html()).toBe(scope.items[0].alert.title);
+      expect(sandboxEl.find('.alert').html()).toContain(scope.items[0].alert.content);
     });
 
     it('should overwrite inherited title when no value specified', function() {
       var elm = compileDirective('default-no-title');
       angular.element(elm[0]).triggerHandler('click');
-      expect(sandboxEl.find('.alert > strong').html()).toBe('');
-      expect(sandboxEl.find('.alert > span').html()).toBe(scope.alert.content);
+      expect(sandboxEl.find('.alert strong').html()).toBeUndefined();
+      expect(sandboxEl.find('.alert').html()).toContain(scope.alert.content);
     });
 
   });


### PR DESCRIPTION
I have faced the leading space in `$alert` when there is no `title` given and I found in the source that it's commented as `TODO`.

This PR is to fix that `TODO` issue.
