### PR TITLE
fix(affix): various fixes (width, resize, bouncing, ngRoutes)

### DIFF
--- a/src/affix/test/affix.spec.js
+++ b/src/affix/test/affix.spec.js
@@ -3,7 +3,7 @@
 
 describe('affix', function () {
 
-  var $compile, scope, sandboxEl;
+  var $compile, scope, sandboxEl, $timeout;
   // var mouse = effroi.mouse;
 
 
@@ -41,11 +41,13 @@ describe('affix', function () {
     var element = $(template.element).appendTo(sandboxEl);
     element = $compile(element)(scope);
     scope.$digest();
+    $timeout.flush();
     return jQuery(element[0]);
   }
-  function sandboxSetup(_$rootScope_, _$compile_) {
+  function sandboxSetup(_$rootScope_, _$compile_, _$timeout_) {
     scope = _$rootScope_;
     $compile = _$compile_;
+    $timeout = _$timeout_;
     sandboxEl = $('<div>').attr('id', 'sandbox').appendTo('body');
   }
   // Tests


### PR DESCRIPTION
* Allow the ability to turn off setting the width in the style using a property
* When calculating the offset, also remove any element style for top (right now
  only position is removed).  This is necessary in order to correctly
  recalculate offsets when the page resizes.
* Fix bouncing when it was affixed to the bottom.  Right now the _unpin property
  will cause a flicker between middle and bottom every other pixel scrolled.
* Add timeout to intializing the affix element.  This allows the page to render
  before calculating offsets and allows it to work when transcluded, as occures
  when using ngRoute.

This is a refinement of #1555 and also closes #1555.
