### PR TITLE
fix(tooltip): TypeError: Cannot read property 'remove' of null" 

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -295,13 +295,15 @@ angular.module('mgcrea.ngStrap.tooltip', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap
           // in leaveAnimateCallback
           _tipToHide = tipElement;
 
-          // Support v1.2+ $animate
-          // https://github.com/angular/angular.js/issues/11713
-          if (angular.version.minor <= 2) {
-            $animate.leave(tipElement, leaveAnimateCallback);
-          } else {
-            $animate.leave(tipElement).then(leaveAnimateCallback);
-          }
+         if (tipElement !== null){
+            // Support v1.2+ $animate
+            // https://github.com/angular/angular.js/issues/11713
+            if (angular.version.minor <= 2) {
+              $animate.leave(tipElement, leaveAnimateCallback);
+            } else {
+              $animate.leave(tipElement).then(leaveAnimateCallback);
+            }
+         }
 
           $tooltip.$isShown = scope.$isShown = false;
           safeDigest(scope);


### PR DESCRIPTION
- Checks whether the tooltip exists before applying animations to it
