### PR TITLE
fix(datepicker): reset validity if date got externally changed

### DIFF
--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -104,6 +104,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         $timepicker.update = function (date) {
           // console.warn('$timepicker.update() newValue=%o', date);
           if (angular.isDate(date) && !isNaN(date.getTime())) {
+            controller.$setValidity('date', true);
             $timepicker.$date = date;
             angular.extend(viewDate, {
               hour: date.getHours(),


### PR DESCRIPTION
When you have a Datetime picker and you change the time to a not valid time ( for example remove a digit ) and you change the day of the date in the date picker. The input in the time picker get updated, but the validation stays on invalid.
This fix should reset the validation when the model changes and the date is valid.
