### PR TITLE
Support for npm with templates included

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./dist/angular-strap.js');
+require('./dist/angular-strap.tpl.min.js');
+module.exports = 'mgcrea.ngStrap';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "angular",
     "bootstrap"
   ],
-  "main": "dist/angular-strap.js",
+  "main": "index.js",
   "homepage": "http://mgcrea.github.io/angular-strap",
   "bugs": "https://github.com/mgcrea/angular-strap/issues",
   "author": {


### PR DESCRIPTION
Gives the ability to require('angular-strap') with no conflicts or errors on npm projects.
The templates are already include.
ex:

``` javascript
var angularStrap = require('angular-strap');

angular
  .module('app', [
     angularStrap
  ]);
```
