### PR TITLE
fix for bsCheckbox and bsRadio: use $viewValue instead of $modelValue for setting isActive state

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -73,15 +73,15 @@ angular.module('mgcrea.ngStrap.button', [])
             return angular.equals(modelValue, trueValue);
           });
           // Fix rendering for exotic values
-          scope.$watch(attr.ngModel, function (newValue, oldValue) {
-            controller.$render();
-          });
+          // scope.$watch(attr.ngModel, function (newValue, oldValue) {
+          //   controller.$render();
+          // });
         }
 
         // model -> view
         controller.$render = function () {
           // console.warn('$render', element.attr('ng-model'), 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue, 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
-          var isActive = angular.equals(controller.$modelValue, trueValue);
+          var isActive = !!controller.$viewValue;
           $$rAF(function () {
             if (isInput) element[0].checked = isActive;
             activeElement.toggleClass(options.activeClass, isActive);
@@ -95,9 +95,9 @@ angular.module('mgcrea.ngStrap.button', [])
             if (!isInput) {
               controller.$setViewValue(!activeElement.hasClass('active'));
             }
-            if (!hasExoticValues) {
+            // if (!hasExoticValues) {
               controller.$render();
-            }
+            // }
           });
         });
 
@@ -155,7 +155,7 @@ angular.module('mgcrea.ngStrap.button', [])
         // model -> view
         controller.$render = function () {
           // console.warn('$render', element.attr('value'), 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue, 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
-          var isActive = angular.equals(controller.$modelValue, value);
+          var isActive = angular.equals(controller.$viewValue, value);
           $$rAF(function () {
             if (isInput) element[0].checked = isActive;
             activeElement.toggleClass(options.activeClass, isActive);

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -72,10 +72,6 @@ angular.module('mgcrea.ngStrap.button', [])
              // console.warn('$formatter("%s"): modelValue=%o (%o)', element.attr('ng-model'), modelValue, typeof modelValue);
             return angular.equals(modelValue, trueValue);
           });
-          // Fix rendering for exotic values
-          // scope.$watch(attr.ngModel, function (newValue, oldValue) {
-          //   controller.$render();
-          // });
         }
 
         // model -> view
@@ -95,9 +91,7 @@ angular.module('mgcrea.ngStrap.button', [])
             if (!isInput) {
               controller.$setViewValue(!activeElement.hasClass('active'));
             }
-            // if (!hasExoticValues) {
-              controller.$render();
-            // }
+            controller.$render();
           });
         });
 


### PR DESCRIPTION
use ngModelController `$viewValue` and not `$modelValue` because the `isActive` state (and so active class of buttons) should be synchronized with viewValue.

For example, if a ngModelOptions is used with debouncing, `$modelValue` still equals the previous value on `$render` execution

That's a fix for #2164. Here is a fiddle using patch : https://jsfiddle.net/elkami/pkj3x9xr/

Thanks for review