### PR TITLE
feat(modal): configurable z-index

### DIFF
--- a/src/modal/docs/modal.demo.html
+++ b/src/modal/docs/modal.demo.html
@@ -268,6 +268,13 @@
             <p>If provided, this function will be invoked before the modal is hidden.</p>
           </td>
         </tr>
+         <td>zIndex</td>
++          <td>number</td>
++          <td>1050</td>
++          <td>
++             CSS z-index value for the modal.
++          </td>
++        </tr>
       </tbody>
     </table>
   </div>

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -20,7 +20,8 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
       keyboard: true,
       html: false,
       show: true,
-      size: null
+      size: null,
+      zIndex: null
     };
 
     this.$get = function ($window, $rootScope, $bsCompiler, $animate, $timeout, $sce, dimensions) {
@@ -49,6 +50,11 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         if (!options.element && !options.container) {
           options.container = 'body';
+        }
+
+        if (options.zIndex) {
+          dialogBaseZindex = parseInt(options.zIndex, 10);
+          backdropBaseZindex = dialogBaseZindex - 10;
         }
 
         // Store $id to identify the triggering element in events
@@ -376,7 +382,7 @@ angular.module('mgcrea.ngStrap.modal', ['mgcrea.ngStrap.core', 'mgcrea.ngStrap.h
 
         // Directive options
         var options = {scope: scope, element: element, show: false};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass', 'customClass', 'modalClass', 'size'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'contentTemplate', 'placement', 'backdrop', 'keyboard', 'html', 'container', 'animation', 'backdropAnimation', 'id', 'prefixEvent', 'prefixClass', 'customClass', 'modalClass', 'size', 'zIndex'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/modal/test/modal.spec.js
+++ b/src/modal/test/modal.spec.js
@@ -106,7 +106,10 @@ describe('modal', function() {
     },
     'options-events': {
       element: '<a bs-on-before-hide="onBeforeHide" bs-on-hide="onHide" bs-on-before-show="onBeforeShow" bs-on-show="onShow" bs-modal="modal">click me</a>'
-    }
+    },
+    'options-z-index': {
+      element: '<a bs-modal="modal" data-z-index="{{zIndex}}">click me</a>'
+    },
   };
 
   function compileDirective(template, locals) {
@@ -738,6 +741,28 @@ describe('modal', function() {
         var elm = compileDirective('options-size-invalid');
         angular.element(elm[0]).triggerHandler('click');
         expect(sandboxEl.find('.modal-dialog')).not.toHaveClass('modal-lg');
+      });
+
+    });
+
+    describe('zIndex', function() {
+
+      it('does not interfere with the default values', function() {
+        var elm = compileDirective('default');
+        angular.element(elm[0]).triggerHandler('click');
+        var modal = bodyEl.find('.modal')[0];
+        var backdrop = bodyEl.find('.modal-backdrop')[0];
+        expect(angular.element(modal).css('z-index')).toBe('1050');
+        expect(angular.element(backdrop).css('z-index')).toBe('1040');
+      });
+
+      it('sets a custom z-index on a modal and decrements the backdrop z-index by 10', function() {
+        var elm = compileDirective('options-z-index', {zIndex: 2000});
+        angular.element(elm[0]).triggerHandler('click');
+        var modal = bodyEl.find('.modal')[0];
+        var backdrop = bodyEl.find('.modal-backdrop')[0];
+        expect(angular.element(modal).css('z-index')).toBe('2000');
+        expect(angular.element(backdrop).css('z-index')).toBe('1990');
       });
 
     });


### PR DESCRIPTION
This PR introduces a configurable z-index for modals. Replaces the stale and outdated #1788.

The modal z-index value defaults to 1050 - the backdrop value is decremented by 10.

