### PR TITLE
fix($select): trigger click on closest anchor tag

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -192,7 +192,23 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
           // Emulate click for mobile devices
           if (isTouch) {
             var targetEl = angular.element(evt.target);
-            targetEl.triggerHandler('click');
+            var anchor;
+
+            if (evt.target.nodeName !== 'A') {
+              var anchorCandidate = targetEl.parent();
+              while (!anchor && anchorCandidate.length > 0) {
+                if (anchorCandidate[0].nodeName === 'A') {
+                  anchor = anchorCandidate;
+                }
+                anchorCandidate = anchorCandidate.parent();
+              }
+            }
+
+            if (anchor) {
+              angular.element(anchor).triggerHandler('click');
+            } else {
+              targetEl.triggerHandler('click');
+            }
           }
         };
 

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -2,7 +2,7 @@
 
 describe('select', function () {
 
-  var $compile, $templateCache, $select, scope, sandboxEl, $timeout, $animate;
+  var $compile, $templateCache, $select, scope, sandboxEl, $timeout, $animate, $window;
 
   beforeEach(module('ngSanitize'));
   beforeEach(module('mgcrea.ngStrap.select'));
@@ -17,6 +17,7 @@ describe('select', function () {
     $select = _$select_;
     $animate = $injector.get('$animate');
     $timeout = $injector.get('$timeout');
+    $window = $injector.get('$window');
     var flush = $animate.flush || $animate.triggerCallbacks;
     $animate.flush = function() {
       flush.call($animate); if(!$animate.triggerCallbacks) $timeout.flush();
@@ -781,4 +782,28 @@ describe('select', function () {
         expect(scope.selectedIcon).toBe(scope.icons[1].value);
     });
   });
+
+  describe('on touch devices', function() {
+
+    var isTouch;
+
+    beforeEach(function() {
+      var isNative = /(ip[ao]d|iphone|android)/ig.test($window.navigator.userAgent);
+      isTouch = ('createTouch' in $window.document) && isNative;
+    });
+
+    it('should select entry on touchstart on span', function() {
+      if (!isTouch) {
+        return;
+      }
+      var elm = compileDirective('default');
+      angular.element(elm[0]).triggerHandler('focus');
+      $timeout.flush();
+      var touchEvent = document.createEvent('TouchEvent');
+      touchEvent.initEvent('touchstart', true, true);
+      sandboxEl.find('.dropdown-menu li:eq(1) a span')[0].dispatchEvent(touchEvent);
+      expect(scope.selectedIcon).toBe(scope.icons[1].value);
+    });
+  })
+
 });


### PR DESCRIPTION
On touch devices a click event is triggered on touchstart on an entry of the select list.
Trigger this emulated click not on the event.target but on the closest parent that is an anchor tag, where the click event triggers the select action.

Fix #2047 and #1580 