### PR TITLE
fix: $typeahead Enable scrolling of typeahead on $keydown when $typeahead.$element container has max-height css set

### DIFF
--- a/docs/styles/main.less
+++ b/docs/styles/main.less
@@ -319,3 +319,8 @@ input[type="checkbox"] {
     max-height: 0px;
   }
 }
+
+.typeahead.dropdown-menu {
+  max-height: 112px;
+  overflow-y: auto;
+}

--- a/src/typeahead/test/typeahead.spec.js
+++ b/src/typeahead/test/typeahead.spec.js
@@ -771,7 +771,38 @@ describe('typeahead', function () {
       expect(hide).toBe(true);
     });
 
+
   });
 
+  xdescribe('keydown', function() {
+
+    it('should not update the typeahead scrollTop', function() {
+      var elm = compileDirective('default'), container;
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val(scope.states[0].substr(0, 1));
+
+      triggerKeyDown (elm, 40);
+      $animate.flush();
+      container = sandboxEl.find('.dropdown-menu')[0];
+      expect(container.scrollTop).toBe(0);
+    });
+
+    it('should update the typeahead containers scrollTop property', function() {
+      var elm = compileDirective('default'), container;
+      angular.element(elm[0]).triggerHandler('focus');
+      elm.val('r');
+      angular.element(elm[0]).triggerHandler('input');
+      $animate.flush();
+
+      triggerKeyDown (elm, 40);
+      triggerKeyDown (elm, 40);
+      triggerKeyDown (elm, 40);
+      triggerKeyDown (elm, 40);
+      triggerKeyDown (elm, 40);
+
+      container = sandboxEl.find('.typeahead.dropdown-menu')[0];
+      expect(container.scrollTop).toBe(container.clientHeight);
+    });
+  });
 
 });

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -115,6 +115,25 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           evt.stopPropagation();
         };
 
+        $typeahead.$$updateScrollTop = function (container, index) {
+          if (index > -1 && index < container.children.length) {
+            var active = container.children[index];
+            var clientTop = active.offsetTop;
+            var clientBottom = active.offsetTop + active.clientHeight;
+            var highWatermark = container.scrollTop;
+            var lowWatermark = container.scrollTop + container.clientHeight;
+
+            // active entry overlaps top border
+            if (clientBottom >= highWatermark && clientTop < highWatermark) {
+              container.scrollTop = Math.max(0, container.scrollTop - container.clientHeight);
+            }
+            // top of active element is invisible because it's below the bottom of the visible container window
+            else if (clientBottom > lowWatermark) {
+              container.scrollTop = clientTop;
+            }
+          }
+        };
+
         $typeahead.$onKeyDown = function (evt) {
           if (!/(38|40|13)/.test(evt.keyCode)) return;
 
@@ -135,6 +154,9 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
           } else if (angular.isUndefined(scope.$activeIndex)) {
             scope.$activeIndex = 0;
           }
+
+          // update scrollTop property on $typeahead when scope.$activeIndex is not in visible area
+          $typeahead.$$updateScrollTop($typeahead.$element[0], scope.$activeIndex);
           scope.$digest();
         };
 

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -126,9 +126,8 @@ angular.module('mgcrea.ngStrap.typeahead', ['mgcrea.ngStrap.tooltip', 'mgcrea.ng
             // active entry overlaps top border
             if (clientBottom >= highWatermark && clientTop < highWatermark) {
               container.scrollTop = Math.max(0, container.scrollTop - container.clientHeight);
-            }
-            // top of active element is invisible because it's below the bottom of the visible container window
-            else if (clientBottom > lowWatermark) {
+            } else if (clientBottom > lowWatermark) {
+              // top of active element is invisible because it's below the bottom of the visible container window
               container.scrollTop = clientTop;
             }
           }


### PR DESCRIPTION
Add function to update scrollTop property on $typeahead.$element when avtive entry leaves visible window of the scrollable container ($typeahead.$element).

Should fix issues
- #1623 and
- #1021.

I tried to add test cases but failed to validate the updated scrollTop property.

Adding test cases to validate setting scrollTop using mock objects should be more painless. I could provide that.

Regards Dirk
