### PR TITLE
added index.js and module.export for compatibility with module bundlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // support for browserify and webpack
 
+requite('./dist/angular-strap.compat.min');
 require('./dist/angular-strap.min');
 require('./dist/angular-strap.tpl.min');
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // support for browserify and webpack
 
-requite('./dist/angular-strap.compat.min');
+require('./dist/angular-strap.compat.min');
 require('./dist/angular-strap.min');
 require('./dist/angular-strap.tpl.min');
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+// support for browserify and webpack
+
+require('./dist/angular-strap.min');
+require('./dist/angular-strap.tpl.min');
+
+module.exports = 'angular-strap';


### PR DESCRIPTION
This will add support for things like webpack and browserify.

## usage

```
angular.module('app.module', [require('angular-strap')]);
```