### PR TITLE
fix(datepicker): disable selecting disabled dates on iOS

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -72,7 +72,8 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
         // Scope methods
 
-        scope.$select = function (date) {
+        scope.$select = function (date, disabled) {
+          if (disabled) return;
           $datepicker.select(date);
         };
         scope.$selectPane = function (value) {

--- a/src/datepicker/datepicker.tpl.html
+++ b/src/datepicker/datepicker.tpl.html
@@ -23,7 +23,7 @@
   <tbody>
     <tr ng-repeat="(i, row) in rows" height="{{ 100 / rows.length }}%">
       <td class="text-center" ng-repeat="(j, el) in row">
-        <button tabindex="-1" type="button" class="btn btn-default" style="width: 100%" ng-class="{'btn-primary': el.selected, 'btn-info btn-today': el.isToday && !el.selected}" ng-click="$select(el.date)" ng-disabled="el.disabled">
+        <button tabindex="-1" type="button" class="btn btn-default" style="width: 100%" ng-class="{'btn-primary': el.selected, 'btn-info btn-today': el.isToday && !el.selected}" ng-click="$select(el.date, el.disabled)" ng-disabled="el.disabled">
           <span ng-class="{'text-muted': el.muted}" ng-bind="el.label"></span>
         </button>
       </td>


### PR DESCRIPTION
On (mobile) Safari ng-click is triggered even when a button is disabled.
Fix: Pass disabled state to $select so we can check before setting clicked
date.