### PR TITLE
Option to allow datepicker for readonly elements

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -41,7 +41,8 @@ angular.module('mgcrea.ngStrap.datepicker', [
       hasToday: false,
       hasClear: false,
       iconLeft: 'glyphicon glyphicon-chevron-left',
-      iconRight: 'glyphicon glyphicon-chevron-right'
+      iconRight: 'glyphicon glyphicon-chevron-right',
+      allowReadonly: false
     };
 
     this.$get = function ($window, $document, $rootScope, $sce, $dateFormatter, datepickerViews, $tooltip, $timeout) {
@@ -249,7 +250,7 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
         var _show = $datepicker.show;
         $datepicker.show = function () {
-          if ((!isTouch && element.attr('readonly')) || element.attr('disabled')) return;
+          if ((!isTouch && element.attr('readonly') && !options.allowReadonly) || element.attr('disabled')) return;
           _show();
           // use timeout to hookup the events to prevent
           // event bubbling from being processed imediately.
@@ -296,7 +297,7 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id', 'prefixClass', 'prefixEvent', 'hasToday', 'hasClear'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id', 'prefixClass', 'prefixEvent', 'hasToday', 'hasClear', 'allowReadonly'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 

--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -323,6 +323,14 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
             <p>Whether the picker has Clear button.</p>
           </td>
         </tr>
+        <tr>
+          <td>allowReadonly</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Allow the picker for readonly element.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -223,6 +223,10 @@ describe('datepicker', function() {
     'options-hasClear': {
       scope: {selectedDate: new Date()},
       element: '<input type="text" ng-model="selectedDate" data-has-clear="true" data-min-date="{{minDate}}" data-date-format="yyyy-MM-dd" bs-datepicker>'
+    },
+    'options-allowReadonly': {
+      scope: {selectedDate: new Date()},
+      element: '<input type="text" ng-model="selectedDate" allow-readonly="true" bs-datepicker>'
     }
   };
 
@@ -1271,6 +1275,18 @@ describe('datepicker', function() {
       });
 
     })
+
+    describe('allowReadonly', function() {
+
+      it('should open for readonly input with allowReadonly true', function() {
+        var elm = compileDirective('options-allowReadonly');
+        expect(sandboxEl.children('.dropdown-menu.datepicker').length).toBe(0);
+        angular.element(elm[0]).triggerHandler('focus');
+        expect(sandboxEl.children('.dropdown-menu.datepicker').length).toBe(1);        
+      });
+
+    });
+
 
   });
 


### PR DESCRIPTION
Bug fix [#946](https://github.com/mgcrea/angular-strap/issues/946) removed calendar for read-only elements which can be useful behavior. This PR allows to explicitly enable the behavior that was removed in "datePicker and timePicker show calendar when ng-readonly="true" #946"