### PR TITLE
fix(bsSelect): Use $viewChangeListeners instead of $watch

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -366,17 +366,17 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
         }, true);
 
         // Watch model for changes
-        scope.$watch(attr.ngModel, function (newValue, oldValue) {
-          // console.warn('scope.$watch(%s)', attr.ngModel, newValue, oldValue);
-          select.$updateActiveIndex();
+        controller.$viewChangeListeners.push(function () {
+          // console.warn('controller.$viewChangeListeners', 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
           controller.$render();
-        }, true);
+        });
 
         // Model rendering in view
         controller.$render = function () {
           // console.warn('$render', element.attr('ng-model'), 'controller.$modelValue', typeof controller.$modelValue, controller.$modelValue, 'controller.$viewValue', typeof controller.$viewValue, controller.$viewValue);
           var selected;
           var index;
+          select.$updateActiveIndex();
           if (options.multiple && angular.isArray(controller.$modelValue)) {
             selected = controller.$modelValue.map(function (value) {
               index = select.$getIndex(value);

--- a/src/select/test/select.spec.js
+++ b/src/select/test/select.spec.js
@@ -34,7 +34,7 @@ describe('select', function () {
   var templates = {
     'default': {
       scope: {selectedIcon: '', icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
-      element: '<button type="button" class="btn" ng-model="selectedIcon" bs-options="icon.value as icon.label for icon in icons" bs-select></button>'
+      element: '<button type="button" class="btn" ng-model="selectedIcon" bs-options="icon.value as icon.label for icon in icons" placeholder="Placeholder text" bs-select></button>'
     },
     'default-with-namespace': {
       scope: {selectedIcon: '', icons: [{value: 'Gear', label: '> Gear'}, {value: 'Globe', label: '> Globe'}, {value: 'Heart', label: '> Heart'}, {value: 'Camera', label: '> Camera'}]},
@@ -168,7 +168,7 @@ describe('select', function () {
     it('should close on select', function() {
       var elm = compileDirective('default');
       expect(sandboxEl.children('.dropdown-menu.select').length).toBe(0);
-      expect(elm.text().trim()).toBe('Choose among the following...');
+      expect(elm.text().trim()).toBe('Placeholder text');
       angular.element(elm[0]).triggerHandler('focus');
       angular.element(sandboxEl.find('.dropdown-menu li:eq(1) a')[0]).triggerHandler('click');
       expect(scope.selectedIcon).toBe(scope.icons[1].value);
@@ -303,6 +303,7 @@ describe('select', function () {
 
       scope.selectedIcon = null;
       scope.$digest();
+      expect(elm.text().trim()).toBe("Placeholder text");
       angular.element(elm[0]).triggerHandler('focus');
       expect(sandboxEl.find('.dropdown-menu li.active').length).toBe(0);
       expect(sandboxEl.find('.dropdown-menu li.active').index()).toBe(-1);


### PR DESCRIPTION
This fixes the case where ngModelOptions specify getterSetter: true. In that
case watching the ngModel attribute does nothing useful, because it will point to
a function rather than a value.

- The directive no longer deep-watches the model (this is default ngModel behaviour)
- No deep-watching should also fix #1966 