### PR TITLE
fix(datepicker): Displaying Date for timezone UTC

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -412,7 +412,12 @@ angular.module('mgcrea.ngStrap.datepicker', [
           //   var today = new Date();
           //   date = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0);
           // }
-          controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          // do not adjust date if timezone is UTC
+          if (options.timezone === 'UTC') {
+            controller.$dateValue = date;
+          } else {
+            controller.$dateValue = dateParser.timezoneOffsetAdjust(date, options.timezone);
+          }
           return getDateFormattedString();
         });
 


### PR DESCRIPTION
Exempting datepicker field with timezone 'UTC' from timezone adjustment.

With existing logic, for a date fed to bsDatepicker with timezone set to UTC, it's $dateValue is being set to adjusted date with respect to client's timezone.

please find the image at [http://imgur.com/a/oj84y](url). In the image it can be seen that $dateValue value for "2017-08-20T00:00:00" is being set as "Sat Aug 19 2017 18:30:00 GMT+0530 (India Standard Time)". This shouldn't happen and so exempting adjustment when timezone is 'UTC'