### PR TITLE
docs(tooltip/popover): Add docs for 'show' option for Tooltips and Popovers

### DIFF
--- a/src/popover/docs/popover.demo.html
+++ b/src/popover/docs/popover.demo.html
@@ -190,6 +190,14 @@
           </td>
         </tr>
         <tr>
+          <td>show</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            Whether to show the popover by default.
+          </td>
+        </tr>
+        <tr>
           <td>onShow</td>
           <td>function</td>
           <td></td>

--- a/src/tooltip/docs/tooltip.demo.html
+++ b/src/tooltip/docs/tooltip.demo.html
@@ -178,6 +178,14 @@
           </td>
         </tr>
         <tr>
+          <td>show</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            Whether to show the tooltip by default.
+          </td>
+        </tr>
+        <tr>
           <td>onShow</td>
           <td>function</td>
           <td></td>


### PR DESCRIPTION
Currently `Tooltip`s and `Popover`s allow a 'show' option during creation (https://github.com/mgcrea/angular-strap/blob/master/src/tooltip/tooltip.js#L137) to specify whether the tooltip/popover should be shown by default. 

However, currently this is not reflected in the list of Options for either Tooltips or Popovers (https://mgcrea.github.io/angular-strap/#/tooltips).
