### PR TITLE
Add option to disable click emulation for touch devices

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -41,7 +41,8 @@ angular.module('mgcrea.ngStrap.datepicker', [
       hasToday: false,
       hasClear: false,
       iconLeft: 'glyphicon glyphicon-chevron-left',
-      iconRight: 'glyphicon glyphicon-chevron-right'
+      iconRight: 'glyphicon glyphicon-chevron-right',
+      touchClickEmulationDisabled: false
     };
 
     this.$get = function ($window, $document, $rootScope, $sce, $dateFormatter, datepickerViews, $tooltip, $timeout) {
@@ -185,7 +186,7 @@ angular.module('mgcrea.ngStrap.datepicker', [
           evt.preventDefault();
           evt.stopPropagation();
           // Emulate click for mobile devices
-          if (isTouch) {
+          if (isTouch && !options.touchClickEmulationDisabled) {
             var targetEl = angular.element(evt.target);
             if (targetEl[0].nodeName.toLowerCase() !== 'button') {
               targetEl = targetEl.parent();
@@ -296,13 +297,13 @@ angular.module('mgcrea.ngStrap.datepicker', [
 
         // Directive options
         var options = {scope: scope};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id', 'prefixClass', 'prefixEvent', 'hasToday', 'hasClear'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'html', 'animation', 'autoclose', 'dateType', 'dateFormat', 'timezone', 'modelDateFormat', 'dayFormat', 'strictFormat', 'startWeek', 'startDate', 'useNative', 'lang', 'startView', 'minView', 'iconLeft', 'iconRight', 'daysOfWeekDisabled', 'id', 'prefixClass', 'prefixEvent', 'hasToday', 'hasClear', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
         // use string regex match boolean attr falsy values, leave truthy values be
         var falseValueRegExp = /^(false|0|)$/i;
-        angular.forEach(['html', 'container', 'autoclose', 'useNative', 'hasToday', 'hasClear'], function (key) {
+        angular.forEach(['html', 'container', 'autoclose', 'useNative', 'hasToday', 'hasClear', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key]) && falseValueRegExp.test(attr[key])) {
             options[key] = false;
           }

--- a/src/datepicker/docs/datepicker.demo.html
+++ b/src/datepicker/docs/datepicker.demo.html
@@ -323,6 +323,14 @@ $scope.untilDate = {{untilDate}}; // &lt;- {{ getType('untilDate') }}
             <p>Whether the picker has Clear button.</p>
           </td>
         </tr>
+        <tr>
+          <td>touchClickEmulationDisabled</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Whether click events are emulated for touchscreens.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/select/docs/select.demo.html
+++ b/src/select/docs/select.demo.html
@@ -255,6 +255,14 @@ $scope.icons = {{icons}};
             The select instance id for usage in event handlers.
           </td>
         </tr>
+        <tr>
+          <td>touchClickEmulationDisabled</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Whether click events are emulated for touchscreens.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -25,7 +25,8 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
       maxLength: 3,
       maxLengthHtml: 'selected',
       iconCheckmark: 'glyphicon glyphicon-ok',
-      toggle: false
+      toggle: false,
+      touchClickEmulationDisabled: false
     };
 
     this.$get = function ($window, $document, $rootScope, $tooltip, $timeout) {
@@ -190,7 +191,7 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
           evt.preventDefault();
           evt.stopPropagation();
           // Emulate click for mobile devices
-          if (isTouch) {
+          if (isTouch && !options.touchClickEmulationDisabled) {
             var targetEl = angular.element(evt.target);
             var anchor;
 
@@ -305,13 +306,13 @@ angular.module('mgcrea.ngStrap.select', ['mgcrea.ngStrap.tooltip', 'mgcrea.ngStr
 
         // Directive options
         var options = {scope: scope, placeholder: defaults.placeholder};
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent', 'toggle'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'placeholder', 'allNoneButtons', 'maxLength', 'maxLengthHtml', 'allText', 'noneText', 'iconCheckmark', 'autoClose', 'id', 'sort', 'caretHtml', 'prefixClass', 'prefixEvent', 'toggle', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
         // use string regex match boolean attr falsy values, leave truthy values be
         var falseValueRegExp = /^(false|0|)$/i;
-        angular.forEach(['html', 'container', 'allNoneButtons', 'sort'], function (key) {
+        angular.forEach(['html', 'container', 'allNoneButtons', 'sort', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key]) && falseValueRegExp.test(attr[key])) {
             options[key] = false;
           }

--- a/src/timepicker/docs/timepicker.demo.html
+++ b/src/timepicker/docs/timepicker.demo.html
@@ -344,6 +344,14 @@ $scope.sharedDate = {{sharedDate}}; // (formatted: {{sharedDate | date:'short'}}
             <p>Sets default date for timepicker + datepicker if date is not selected yet. You can use the string 'today' to set today, or 'auto' to set 01.01.1970.</p>
           </td>
         </tr>
+        <tr>
+          <td>touchClickEmulationDisabled</td>
+          <td>boolean</td>
+          <td>false</td>
+          <td>
+            <p>Whether click events are emulated for touchscreens.</p>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -33,7 +33,8 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
       roundDisplay: false,
       iconUp: 'glyphicon glyphicon-chevron-up',
       iconDown: 'glyphicon glyphicon-chevron-down',
-      arrowBehavior: 'pager'
+      arrowBehavior: 'pager',
+      touchClickEmulationDisabled: false
     };
 
     this.$get = function ($window, $document, $rootScope, $sce, $dateFormatter, $tooltip, $timeout) {
@@ -274,7 +275,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
           if (evt.target.nodeName.toLowerCase() !== 'input') evt.preventDefault();
           evt.stopPropagation();
           // Emulate click for mobile devices
-          if (isTouch) {
+          if (isTouch && !options.touchClickEmulationDisabled) {
             var targetEl = angular.element(evt.target);
             if (targetEl[0].nodeName.toLowerCase() !== 'button') {
               targetEl = targetEl.parent();
@@ -439,13 +440,13 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         var options = {
           scope: scope
         };
-        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'secondStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'roundDisplay', 'id', 'prefixClass', 'prefixEvent', 'defaultDate'], function (key) {
+        angular.forEach(['template', 'templateUrl', 'controller', 'controllerAs', 'placement', 'container', 'delay', 'trigger', 'keyboard', 'html', 'animation', 'autoclose', 'timeType', 'timeFormat', 'timezone', 'modelTimeFormat', 'useNative', 'hourStep', 'minuteStep', 'secondStep', 'length', 'arrowBehavior', 'iconUp', 'iconDown', 'roundDisplay', 'id', 'prefixClass', 'prefixEvent', 'defaultDate', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key])) options[key] = attr[key];
         });
 
         // use string regex match boolean attr falsy values, leave truthy values be
         var falseValueRegExp = /^(false|0|)$/i;
-        angular.forEach(['html', 'container', 'autoclose', 'useNative', 'roundDisplay'], function (key) {
+        angular.forEach(['html', 'container', 'autoclose', 'useNative', 'roundDisplay', 'touchClickEmulationDisabled'], function (key) {
           if (angular.isDefined(attr[key]) && falseValueRegExp.test(attr[key])) {
             options[key] = false;
           }


### PR DESCRIPTION
When using angular strap in combination with angular material both components emulate the click on touch devices. This leads to ng-click functions being called twice. The datepicker next/prev month buttons for example skip every other month on touch devices.